### PR TITLE
Avoid divide by zero

### DIFF
--- a/src/AmortisationSchedule.fs
+++ b/src/AmortisationSchedule.fs
@@ -147,8 +147,10 @@ module Amortisation =
             
             let feesDue =
                 match sp.FeesAndCharges.FeesSettlement with
-                | Fees.Settlement.DueInFull -> feesTotal
-                | Fees.Settlement.ProRataRefund -> decimal feesTotal * decimal ap.AppliedPaymentDay / decimal originalFinalPaymentDay |> Cent.round RoundDown
+                | Fees.Settlement.ProRataRefund when originalFinalPaymentDay > 0<OffsetDay> -> 
+                    decimal feesTotal * decimal ap.AppliedPaymentDay / decimal originalFinalPaymentDay |> Cent.round RoundDown
+                | Fees.Settlement.DueInFull 
+                | _ -> feesTotal
             let feesRemaining = if ap.AppliedPaymentDay > originalFinalPaymentDay then 0L<Cent> else Cent.max 0L<Cent> (feesTotal - feesDue)
 
             let settlementFigure = a.PrincipalBalance + a.FeesBalance - feesRemaining + interestPortion + chargesPortion


### PR DESCRIPTION
On a final payment that is originally due on day zero, the calculation caused a divide by zero. Shouldn't happen but can, and can be easily avoided by this commit.