### PR TITLE
DateOnly conversion functions

### DIFF
--- a/src/DateDay.fs
+++ b/src/DateDay.fs
@@ -58,10 +58,6 @@ module DateDay =
         let FromDate (d:Date) =
             DateOnly(d.Year, d.Month, d.Day)
 
-        [<System.Runtime.CompilerServices.Extension>]
-        let ToDate (d:DateOnly) =
-            Date(d.Year, d.Month, d.Day)
-
     type DateOnly with
         member this.ToDate () =
             Date(this.Year, this.Month, this.Day)

--- a/src/DateDay.fs
+++ b/src/DateDay.fs
@@ -52,3 +52,18 @@ module DateDay =
     module TrackingDay =
         /// create a date from a year, month, and tracking day
         let toDate y m td = Date(y, m, min (Date.DaysInMonth(y, m)) td)
+
+    #if DATEONLY
+    module DateOnly =
+        let FromDate (d:Date) =
+            DateOnly(d.Year, d.Month, d.Day)
+
+        [<System.Runtime.CompilerServices.Extension>]
+        let ToDate (d:DateOnly) =
+            Date(d.Year, d.Month, d.Day)
+
+    type DateOnly with
+        member this.ToDate () =
+            Date(this.Year, this.Month, this.Day)
+
+    #endif

--- a/src/FSharp.Finance.Personal.fsproj
+++ b/src/FSharp.Finance.Personal.fsproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0' " >DATEONLY</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>


### PR DESCRIPTION
Here are functions to easily convert .NET DateOnly to DateDay.Date.
This follows the current user experience of DateOnly:

```fsharp
let myDT = DateOnly(1999,1,15).ToDateTime()
let myDateOnly = DateOnly.FromDateTime DateTIme.Now
```

with

```fsharp
let myDate = DateOnly(1999,1,15).ToDate()
let myDateOnly = DateOnly.FromDate mydateday
```

However, there is a catch to get this into use: 
This PR won't have effect to anything in the current build.
The DateDay is not part of .NET Standard 2.0 neither .NET Standard 2.1 but only .NET6 and .NET8. Thus, if we want to add this support then more target frameworks need to be added:
`<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>` vs
`<TargetFrameworks>net8.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>`

