### PR TITLE
Try to solve contractual interest on irregular schedule.

### DIFF
--- a/src/Amortisation.fs
+++ b/src/Amortisation.fs
@@ -668,7 +668,16 @@ module Amortisation =
                 )
                 |> Array.concat, 0L<Cent>
             | IrregularSchedule payments ->
-                payments, 0L<Cent>
+                match scheduleType, sp.Interest.Method with
+                | ScheduleType.Original, Interest.Method.AddOn ->
+                    // Contractual interest has to be solved. 
+                    // Hack to get it here, because the payment schedule days may not match, but this is more correct than zero.
+                    let schedule = PaymentSchedule.calculate BelowZero sp
+                    match schedule with
+                    | ValueSome s -> payments, s.InitialInterestBalance
+                    | ValueNone -> payments, 0L<Cent>
+                | _ ->
+                    payments, 0L<Cent>
 
         if Array.isEmpty payments then ValueNone else
 


### PR DESCRIPTION
Current irregular schedule puts the contractual interest to zero, which creates very interesting amortization-schedules. 
This PR will put there a value according to a generated schedule, which will yield better amortization-schedules.
(This works well if the original irregular schedule is actually created with a backward-compatible version of this library.)

Ultimately we should try to solve the contractual interest fixed with the schedule-dates given in the irregular schedule, but I expect this would be a bigger change.
