### PR TITLE
Extract the generation info to a separate page

### DIFF
--- a/src/Amortisation.fs
+++ b/src/Amortisation.fs
@@ -355,12 +355,14 @@ module Amortisation =
 <h4>Advanced Parameters</h4>{AdvancedParameters.toHtmlTable p.Advanced}"""
 
             let generateInfoFile = "GeneratedDate.md"
+
             let htmlDatestamp =
                 $"""
-<p>Generated: <i>[see details](../{generateInfoFile})</i></p>"""
+<p>Generated: <i><a href="../{generateInfoFile}">see details</a></i></p>"""
+
             let htmlDatestampInfo =
                 $"""
-<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {Calculation.libraryVersion}</i></p>"""
+<p>Generated: <i>{DateTimeOffset.Now:``yyyy-MM-dd HH:mm:ss zzzz``} using library version {Calculation.libraryVersion}</i></p>"""
 
             let htmlFinalStats =
                 $"""
@@ -376,9 +378,9 @@ module Amortisation =
             |> outputToFile' filename false
 
             try
-                $"""{htmlDatestampInfo}"""
-                |> outputToFile' $"out/{generateInfoFile}" false
-            with _ -> ()
+                $"""{htmlDatestampInfo}""" |> outputToFile' $"out/{generateInfoFile}" false
+            with _ ->
+                ()
 
     /// calculates the fee total as a percentage of the principal, for further calculation (weighting payments made when apportioning to fee and principal)
     let feePercentage principal feeTotal =

--- a/src/Amortisation.fs
+++ b/src/Amortisation.fs
@@ -354,9 +354,13 @@ module Amortisation =
                 $"""
 <h4>Advanced Parameters</h4>{AdvancedParameters.toHtmlTable p.Advanced}"""
 
+            let generateInfoFile = "GeneratedDate.md"
             let htmlDatestamp =
                 $"""
-<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {libraryVersion}</i></p>"""
+<p>Generated: <i>[see details](../{generateInfoFile})</i></p>"""
+            let htmlDatestampInfo =
+                $"""
+<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {Calculation.libraryVersion}</i></p>"""
 
             let htmlFinalStats =
                 $"""
@@ -370,6 +374,11 @@ module Amortisation =
 
             $"{htmlTitle}{htmlSchedule}{htmlDescription}{htmlDatestamp}{htmlBasicParams}{htmlAdvancedParams}{htmlFinalStats}{htmlAmortisationStats}"
             |> outputToFile' filename false
+
+            try
+                $"""{htmlDatestampInfo}"""
+                |> outputToFile' $"out/{generateInfoFile}" false
+            with _ -> ()
 
     /// calculates the fee total as a percentage of the principal, for further calculation (weighting payments made when apportioning to fee and principal)
     let feePercentage principal feeTotal =

--- a/src/Scheduling.fs
+++ b/src/Scheduling.fs
@@ -682,7 +682,11 @@ module Scheduling =
                 $"""
 <h4>Basic Parameters</h4>{BasicParameters.toHtmlTable bp}"""
 
+            let generateInfoFile = "GeneratedDate.md"
             let htmlDatestamp =
+                $"""
+<p>Generated: <i>[see details](../{generateInfoFile})</i></p>"""
+            let htmlDatestampInfo =
                 $"""
 <p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {Calculation.libraryVersion}</i></p>"""
 
@@ -694,6 +698,11 @@ module Scheduling =
 
             $"""{htmlTitle}{htmlSchedule}{htmlDescription}{htmlDatestamp}{htmlParams}{htmlFinalStats}"""
             |> outputToFile' filename false
+
+            try
+                $"""{htmlDatestampInfo}"""
+                |> outputToFile' $"out/{generateInfoFile}" false
+            with _ -> ()
 
     /// convert an option to a value option
     let toValueOption =

--- a/src/Scheduling.fs
+++ b/src/Scheduling.fs
@@ -683,12 +683,14 @@ module Scheduling =
 <h4>Basic Parameters</h4>{BasicParameters.toHtmlTable bp}"""
 
             let generateInfoFile = "GeneratedDate.md"
+
             let htmlDatestamp =
                 $"""
-<p>Generated: <i>[see details](../{generateInfoFile})</i></p>"""
+<p>Generated: <i><a href="../{generateInfoFile}">see details</a></i></p>"""
+
             let htmlDatestampInfo =
                 $"""
-<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {Calculation.libraryVersion}</i></p>"""
+<p>Generated: <i>{DateTimeOffset.Now:``yyyy-MM-dd HH:mm:ss zzzz``} using library version {Calculation.libraryVersion}</i></p>"""
 
             let htmlFinalStats =
                 $"""
@@ -700,9 +702,9 @@ module Scheduling =
             |> outputToFile' filename false
 
             try
-                $"""{htmlDatestampInfo}"""
-                |> outputToFile' $"out/{generateInfoFile}" false
-            with _ -> ()
+                $"""{htmlDatestampInfo}""" |> outputToFile' $"out/{generateInfoFile}" false
+            with _ ->
+                ()
 
     /// convert an option to a value option
     let toValueOption =

--- a/tests/AprEuropeanUnionTests.fs
+++ b/tests/AprEuropeanUnionTests.fs
@@ -198,14 +198,23 @@ module AprEuropeanUnionTests =
             $"""
 <h4>Advanced Parameters</h4>{AdvancedParameters.toHtmlTable parameters.Advanced}"""
 
+        let generateInfoFile = "GeneratedDate.md"
         let htmlDatestamp =
             $"""
-<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {libraryVersion}</i></p>"""
+<p>Generated: <i>[see details](../{generateInfoFile})</i></p>"""
+        let htmlDatestampInfo =
+            $"""
+<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {Calculation.libraryVersion}</i></p>"""
 
         let filename = $"out/{folder}/{title}.md"
 
         $"{htmlTitle}{htmlTable}{htmlDescription}{htmlDatestamp}{htmlBasicParams}{htmlAdvancedParams}"
         |> outputToFile' filename false
+
+        try
+            $"""{htmlDatestampInfo}"""
+            |> outputToFile' $"out/{generateInfoFile}" false
+        with _ -> ()
 
     let startDate = Date(2025, 4, 1)
     let paymentCounts = [| 4..6 |]

--- a/tests/AprEuropeanUnionTests.fs
+++ b/tests/AprEuropeanUnionTests.fs
@@ -199,12 +199,14 @@ module AprEuropeanUnionTests =
 <h4>Advanced Parameters</h4>{AdvancedParameters.toHtmlTable parameters.Advanced}"""
 
         let generateInfoFile = "GeneratedDate.md"
+
         let htmlDatestamp =
             $"""
-<p>Generated: <i>[see details](../{generateInfoFile})</i></p>"""
+<p>Generated: <i><a href="../{generateInfoFile}">see details</a></i></p>"""
+
         let htmlDatestampInfo =
             $"""
-<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {Calculation.libraryVersion}</i></p>"""
+<p>Generated: <i>{DateTimeOffset.Now:``yyyy-MM-dd HH:mm:ss zzzz``} using library version {Calculation.libraryVersion}</i></p>"""
 
         let filename = $"out/{folder}/{title}.md"
 
@@ -212,9 +214,9 @@ module AprEuropeanUnionTests =
         |> outputToFile' filename false
 
         try
-            $"""{htmlDatestampInfo}"""
-            |> outputToFile' $"out/{generateInfoFile}" false
-        with _ -> ()
+            $"""{htmlDatestampInfo}""" |> outputToFile' $"out/{generateInfoFile}" false
+        with _ ->
+            ()
 
     let startDate = Date(2025, 4, 1)
     let paymentCounts = [| 4..6 |]

--- a/tests/AprUnitedKingdomTests.fs
+++ b/tests/AprUnitedKingdomTests.fs
@@ -199,12 +199,14 @@ module AprUnitedKingdomTests =
 <h4>Advanced Parameters</h4>{AdvancedParameters.toHtmlTable parameters.Advanced}"""
 
         let generateInfoFile = "GeneratedDate.md"
+
         let htmlDatestamp =
             $"""
-<p>Generated: <i>[see details](../{generateInfoFile})</i></p>"""
+<p>Generated: <i><a href="../{generateInfoFile}">see details</a></i></p>"""
+
         let htmlDatestampInfo =
             $"""
-<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {Calculation.libraryVersion}</i></p>"""
+<p>Generated: <i>{DateTimeOffset.Now:``yyyy-MM-dd HH:mm:ss zzzz``} using library version {Calculation.libraryVersion}</i></p>"""
 
         let filename = $"out/{folder}/{title}.md"
 
@@ -212,9 +214,9 @@ module AprUnitedKingdomTests =
         |> outputToFile' filename false
 
         try
-            $"""{htmlDatestampInfo}"""
-            |> outputToFile' $"out/{generateInfoFile}" false
-        with _ -> ()
+            $"""{htmlDatestampInfo}""" |> outputToFile' $"out/{generateInfoFile}" false
+        with _ ->
+            ()
 
     let startDate = Date(2025, 4, 1)
     let paymentCounts = [| 4..6 |]

--- a/tests/AprUnitedKingdomTests.fs
+++ b/tests/AprUnitedKingdomTests.fs
@@ -198,14 +198,23 @@ module AprUnitedKingdomTests =
             $"""
 <h4>Advanced Parameters</h4>{AdvancedParameters.toHtmlTable parameters.Advanced}"""
 
+        let generateInfoFile = "GeneratedDate.md"
         let htmlDatestamp =
             $"""
-<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {libraryVersion}</i></p>"""
+<p>Generated: <i>[see details](../{generateInfoFile})</i></p>"""
+        let htmlDatestampInfo =
+            $"""
+<p>Generated: <i>{DateTime.Now.ToString "yyyy-MM-dd"} using library version {Calculation.libraryVersion}</i></p>"""
 
         let filename = $"out/{folder}/{title}.md"
 
         $"{htmlTitle}{htmlTable}{htmlDescription}{htmlDatestamp}{htmlBasicParams}{htmlAdvancedParams}"
         |> outputToFile' filename false
+
+        try
+            $"""{htmlDatestampInfo}"""
+            |> outputToFile' $"out/{generateInfoFile}" false
+        with _ -> ()
 
     let startDate = Date(2025, 4, 1)
     let paymentCounts = [| 4..6 |]


### PR DESCRIPTION
Just an idea: If the generated date-stamp were on a separate markdown file, then every file wouldn't have a change when you run tests, and there would be only one file to commit (or maybe git-ignore?).