### PR TITLE
Fix possible key not found exception case

### DIFF
--- a/src/Amortisation.fs
+++ b/src/Amortisation.fs
@@ -411,7 +411,12 @@ module Amortisation =
         match unitPeriodMap with
         | Some upm ->
             // use the unit-period map to determine the window for the current day
-            upm |> Map.find currentDay
+            upm 
+            |> Map.tryFind currentDay 
+            |> Option.defaultValue (
+                if ScheduledPayment.isSome currentScheduledPayment then 
+                    previousWindow + 1 
+                else previousWindow )
         | None ->
             // determine the window and increment every time a new scheduled payment is due
             if ScheduledPayment.isSome currentScheduledPayment then


### PR DESCRIPTION
Just a small addition on unprobable case to work the same way as 2.5.2 version was doing (where this didn't happen).
