### PR TITLE
Consolidated Equipment Finance Domain added: Loans, Leases, US MACRS, UK Capital Allowances

### DIFF
--- a/docs/EquipmentFinance.md
+++ b/docs/EquipmentFinance.md
@@ -53,7 +53,7 @@ src/EquipmentFinance/
 open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
 
 let computer = {
-    CostBasis = 1000000L<Cent> // $10,000
+    CostBasis = 10000_00L<Cent> // $10,000
     PlacedInServiceDate = Date(2024, 1, 1)
     PropertyClass = Types.AssetClass.FiveYear
     Convention = Types.Convention.HalfYear
@@ -114,14 +114,14 @@ let schedule = Calculations.scheduleDefault machinery
 open FSharp.Finance.Personal.EquipmentFinance
 
 let loanTerms = {
-    Principal = 1000000L<Cent> // $10,000
+    Principal = 10000_00L<Cent> // $10,000
     InterestRate = Interest.Rate.Annual (Percent 6.0m)
     TermMonths = 36
     MonthlyPayment = None
     EquipmentDescription = "Manufacturing Equipment"
-    EquipmentCost = 1000000L<Cent>
-    DownPayment = 200000L<Cent>
-    ResidualValue = 100000L<Cent>
+    EquipmentCost = 10000_00L<Cent>
+    DownPayment = 2000_00L<Cent>
+    ResidualValue = 1000_00L<Cent>
 }
 
 let analysis = Loan.analyzeLoan loanTerms startDate
@@ -143,14 +143,14 @@ open FSharp.Finance.Personal.EquipmentFinance
 
 let leaseTerms = {
     EquipmentDescription = "Manufacturing Equipment"
-    FairMarketValue = 1000000L<Cent>
+    FairMarketValue = 10000_00L<Cent>
     TermMonths = 36
     LeaseType = Lease.LeaseType.FinanceLease
     PaymentFrequency = Lease.PaymentFrequency.Monthly
-    LeasePayment = 30000L<Cent>
-    UpfrontPayment = 100000L<Cent>
-    ResidualValue = 200000L<Cent>
-    PurchaseOption = Some 200000L<Cent>
+    LeasePayment = 300_00L<Cent>
+    UpfrontPayment = 1000_00L<Cent>
+    ResidualValue = 2000_00L<Cent>
+    PurchaseOption = Some 2000_00L<Cent>
     ImplicitRate = Interest.Rate.Annual (Percent 5.0m)
 }
 
@@ -185,13 +185,6 @@ All modules integrate seamlessly with the existing FSharp.Finance.Personal libra
 - Uses `DateDay.Date` for date handling
 - Follows existing functional programming patterns
 
-## Superseded PRs
-
-This implementation consolidates and supersedes:
-
-- **PR #5**: "Implement initial Equipment Finance & Leasing scaffolding"
-- **PR #9**: "WIP depreciation restructuring adding UK Capital Allowances"
-
 The consolidated implementation provides:
 
 - Consistent namespacing as specified in requirements
@@ -220,6 +213,3 @@ Potential areas for expansion:
 - Support for partial-year conventions
 - Multiple asset management capabilities
 
----
-
-**Note**: This documentation describes the consolidated Equipment Finance implementation that supersedes PRs #5 and #9, providing a unified and comprehensive solution for equipment finance analysis.

--- a/docs/EquipmentFinance.md
+++ b/docs/EquipmentFinance.md
@@ -38,8 +38,8 @@ src/EquipmentFinance/
 
 ## Depreciation Common Module
 
-- `Depreciation.straightLine cost salvage life`
-- `Depreciation.decliningBalance cost salvage life rateFactor switchToStraightLine`
+- `DepreciationCommon.Calculations.straightLine cost salvage life`
+- `DepreciationCommon.Calculations.decliningBalance cost salvage life rateFactor switchToStraightLine`
 
 ## US MACRS Depreciation
 
@@ -55,11 +55,12 @@ src/EquipmentFinance/
 ### Example Usage
 
 ```fsharp
+open FSharp.Finance.Personal
 open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
 
 let computer = {
     CostBasis = 10000_00L<Cent> // $10,000
-    PlacedInServiceDate = Date(2024, 1, 1)
+    PlacedInServiceDate = DateDay.Date(2024, 1, 1)
     PropertyClass = Types.AssetClass.FiveYear
     Convention = Types.Convention.HalfYear
 }
@@ -85,10 +86,11 @@ let schedule = Calculations.generateSchedule computer
 ### Example Usage
 
 ```fsharp
+open FSharp.Finance.Personal
 open FSharp.Finance.Personal.EquipmentFinance.Depreciation.UK_CapitalAllowances
 
 let machinery = {
-    Amount = 50_000m
+    Amount = 50_000_00L<Cent>
     Pool = Types.Pool.Main
     Description = "Manufacturing equipment"
 }
@@ -111,7 +113,7 @@ let schedule = Calculations.scheduleDefault machinery
 - Monthly payment calculation with various interest rates
 - Complete amortization schedule generation
 - Integration with MACRS depreciation analysis
-- Support for residual values and down payments
+- Support for residual values; `Principal` is the financed amount after any down payment
 
 ### Example Usage
 
@@ -217,4 +219,3 @@ Potential areas for expansion:
 - Integration with tax calculation modules
 - Support for partial-year conventions
 - Multiple asset management capabilities
-

--- a/docs/EquipmentFinance.md
+++ b/docs/EquipmentFinance.md
@@ -52,6 +52,13 @@ src/EquipmentFinance/
 - **15-Year Property**: Land improvements, gas stations
 - **20-Year Property**: Farm buildings, utility property
 
+Real property (buildings, warehouses, etc.) is **not** supported: under MACRS, buildings are
+27.5-year (residential) / 39-year (nonresidential) straight-line property, so
+`classifyAsset`/`tryClassifyAsset` reject building descriptions with a descriptive error
+instead of misclassifying them. `tryClassifyAsset` returns `None` for unrecognized
+descriptions; `classifyAsset` defaults those to 5-year property, and the analysis functions
+surface that assumption via the `AssetClassAssumed` flag.
+
 ### Example Usage
 
 ```fsharp
@@ -72,9 +79,10 @@ let schedule = Calculations.generateSchedule computer
 ### Key Features
 
 - Half-year convention implementation
-- Educational percentage tables for all asset classes
+- IRS Table A-1 percentage tables for all supported asset classes (each table sums to
+  exactly 100% of basis)
 - Complete year-by-year depreciation calculations
-- Asset classification helper function
+- Asset classification helper functions (`classifyAsset` / `tryClassifyAsset`)
 
 ## UK Capital Allowances
 
@@ -96,15 +104,19 @@ let machinery = {
 }
 
 let schedule = Calculations.scheduleDefault machinery
-// Returns schedule with AIA in year 1, then WDA in subsequent years
+// Returns an AllowanceSchedule: schedule.Years has AIA in year 1 then WDA in subsequent
+// years; schedule.UnclaimedPool reports any pool value left when MaxYears is reached
 ```
 
 ### Key Features
 
 - Annual Investment Allowance (AIA) application
 - Writing Down Allowances with proper rates
+- HMRC small pools allowance: a pool balance at or below `SmallPoolThreshold`
+  (default £1,000) is written off in full that year
+- Explicit `UnclaimedPool` reporting when the schedule is truncated at `MaxYears`
 - Midpoint-away-from-zero rounding
-- Configurable AIA limits and maximum years
+- Configurable AIA limits, small-pool threshold and maximum years
 
 ## Equipment Loans
 
@@ -113,7 +125,17 @@ let schedule = Calculations.scheduleDefault machinery
 - Monthly payment calculation with various interest rates
 - Complete amortization schedule generation
 - Integration with MACRS depreciation analysis
-- Support for residual values; `Principal` is the financed amount after any down payment
+- Support for residual values; `Principal` is the financed amount after any down payment.
+  The balance amortizes down to the residual and the final payment settles it as a
+  balloon, reported separately in the schedule's `BalloonAmount` column.
+  `ResidualValue = Principal` models an interest-only balloon loan.
+- Optional recurring `MonthlyFee`, shown as its own `FeePayment` column
+  (payment = principal + interest + fee) and included in `TotalPayments`/`TotalFees`
+- With a supplied `MonthlyPayment`, payments that would not cover the first period's
+  interest are rejected, and an overpaying schedule terminates early once the balance is
+  repaid instead of producing negative rows
+- `PaymentCalculation.NominalAnnualRate` is the nominal input rate used for the schedule;
+  no effective APR is computed
 
 ### Example Usage
 
@@ -125,14 +147,16 @@ let loanTerms = {
     InterestRate = Interest.Rate.Annual (Percent 6.0m)
     TermMonths = 36
     MonthlyPayment = None
+    MonthlyFee = None
     EquipmentDescription = "Manufacturing Equipment"
     EquipmentCost = 10000_00L<Cent>
     DownPayment = 2000_00L<Cent>
     ResidualValue = 1000_00L<Cent>
 }
 
-let analysis = Loan.analyzeLoan loanTerms startDate
-// Returns comprehensive loan analysis including depreciation
+let analysis = Loan.analyzeLoan loanTerms startDate (Percent 8.0m)
+// Returns comprehensive loan analysis including depreciation and the NPV of the loan
+// cash flows discounted at the supplied annual rate
 ```
 
 ## Equipment Leases
@@ -154,22 +178,33 @@ let leaseTerms = {
     TermMonths = 36
     LeaseType = Lease.LeaseType.FinanceLease
     PaymentFrequency = Lease.PaymentFrequency.Monthly
-    LeasePayment = 300_00L<Cent>
+    PaymentTiming = Lease.PaymentTiming.InAdvance
+    LeasePayment = 0L<Cent> // 0 = calculate the level rental from the other terms
+    PeriodicFee = None
     UpfrontPayment = 1000_00L<Cent>
     ResidualValue = 2000_00L<Cent>
     PurchaseOption = Some 2000_00L<Cent>
     ImplicitRate = Interest.Rate.Annual (Percent 5.0m)
 }
 
-let analysis = Lease.analyzeLeaseVsBuy leaseTerms startDate
-// Returns lease vs buy analysis with depreciation comparison
+let analysis = Lease.analyzeLeaseVsBuy leaseTerms startDate (Percent 8.0m)
+// Returns lease vs buy analysis with depreciation comparison and the net advantage to
+// leasing (NPV of buying minus NPV of leasing at the supplied discount rate)
 ```
 
 ### Key Features
 
 - Multiple payment frequencies (monthly, quarterly, etc.)
+- Payments in advance (annuity-due, the usual convention for equipment leases) or in
+  arrears via `PaymentTiming`
+- The contractual rental is honoured every period; the final period is a plug that lands
+  exactly on the residual. Stated rentals that cannot land on the residual (too high or
+  too low) are rejected with an error quoting the consistent level rental.
+- Optional recurring `PeriodicFee`, shown as its own `FeePortion` column and included in
+  the totals
 - Present value calculations
-- Lease vs. buy analysis with depreciation integration
+- Lease vs. buy analysis with depreciation integration and a computed
+  `NetAdvantageToLeasing` (simple pre-tax NPV comparison)
 - Support for purchase options
 
 ## Common Features
@@ -214,8 +249,9 @@ Comprehensive test suites are provided for all modules:
 
 Potential areas for expansion:
 
-- Additional depreciation methods (e.g., declining balance)
-- More sophisticated lease vs. buy NPV analysis
+- More sophisticated lease vs. buy NPV analysis (tax effects, after-tax discount rates)
+- Effective APR calculation for loans and leases (the current
+  `NominalAnnualRate` fields report the nominal input rate only)
 - Integration with tax calculation modules
 - Support for partial-year conventions
 - Multiple asset management capabilities

--- a/docs/EquipmentFinance.md
+++ b/docs/EquipmentFinance.md
@@ -36,6 +36,11 @@ src/EquipmentFinance/
 └── Lease.fs                       # Equipment lease analysis
 ```
 
+## Depreciation Common Module
+
+- `Depreciation.straightLine cost salvage life`
+- `Depreciation.decliningBalance cost salvage life rateFactor switchToStraightLine`
+
 ## US MACRS Depreciation
 
 ### Asset Classes Supported

--- a/docs/EquipmentFinance.md
+++ b/docs/EquipmentFinance.md
@@ -1,0 +1,225 @@
+# Equipment Finance Module Documentation
+
+This document provides comprehensive documentation for the Equipment Finance modules in FSharp.Finance.Personal, which consolidate and supersede PRs #5 and #9.
+
+## Overview
+
+The Equipment Finance modules provide analytical capabilities for equipment financing scenarios including:
+
+- **Equipment Loans**: Complete loan analysis with amortization schedules
+- **Equipment Leases**: Lease calculations and lease vs. buy analysis
+- **Depreciation**: Both US MACRS and UK Capital Allowances calculations
+
+## Important Disclaimer
+
+⚠️ **EDUCATIONAL PURPOSES ONLY**: These modules are for educational and analytical purposes only. They are NOT tax advice and should not be used for actual tax calculations without validation by qualified tax professionals.
+
+## Module Structure
+
+### Namespaces
+
+- `FSharp.Finance.Personal.EquipmentFinance.Depreciation` - Common depreciation utilities
+- `FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS` - US MACRS depreciation
+- `FSharp.Finance.Personal.EquipmentFinance.Depreciation.UK_CapitalAllowances` - UK Capital Allowances
+- `FSharp.Finance.Personal.EquipmentFinance.Loan` - Equipment loan calculations
+- `FSharp.Finance.Personal.EquipmentFinance.Lease` - Equipment lease calculations
+
+### File Organization
+
+```
+src/EquipmentFinance/
+├── Depreciation/
+│   ├── DepreciationCommon.fs      # Shared utilities and abstractions
+│   ├── US_MACRS.fs                # US MACRS depreciation calculations
+│   └── UK_CapitalAllowances.fs    # UK Capital Allowances calculations
+├── Loan.fs                        # Equipment loan analysis
+└── Lease.fs                       # Equipment lease analysis
+```
+
+## US MACRS Depreciation
+
+### Asset Classes Supported
+
+- **3-Year Property**: Special tools, small manufacturing equipment
+- **5-Year Property**: Computers, office machinery, vehicles (default)
+- **7-Year Property**: Office furniture, most equipment
+- **10-Year Property**: Boats, barges, single-purpose structures
+- **15-Year Property**: Land improvements, gas stations
+- **20-Year Property**: Farm buildings, utility property
+
+### Example Usage
+
+```fsharp
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
+
+let computer = {
+    CostBasis = 1000000L<Cent> // $10,000
+    PlacedInServiceDate = Date(2024, 1, 1)
+    PropertyClass = Types.AssetClass.FiveYear
+    Convention = Types.Convention.HalfYear
+}
+
+let schedule = Calculations.generateSchedule computer
+// Returns 6-year depreciation schedule with proper percentages
+```
+
+### Key Features
+
+- Half-year convention implementation
+- Educational percentage tables for all asset classes
+- Complete year-by-year depreciation calculations
+- Asset classification helper function
+
+## UK Capital Allowances
+
+### Pool Types Supported
+
+- **Main Pool**: 18% Writing Down Allowance rate
+- **Special Rate Pool**: 6% Writing Down Allowance rate (vehicles, etc.)
+
+### Example Usage
+
+```fsharp
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.UK_CapitalAllowances
+
+let machinery = {
+    Amount = 50_000m
+    Pool = Types.Pool.Main
+    Description = "Manufacturing equipment"
+}
+
+let schedule = Calculations.scheduleDefault machinery
+// Returns schedule with AIA in year 1, then WDA in subsequent years
+```
+
+### Key Features
+
+- Annual Investment Allowance (AIA) application
+- Writing Down Allowances with proper rates
+- Midpoint-away-from-zero rounding
+- Configurable AIA limits and maximum years
+
+## Equipment Loans
+
+### Capabilities
+
+- Monthly payment calculation with various interest rates
+- Complete amortization schedule generation
+- Integration with MACRS depreciation analysis
+- Support for residual values and down payments
+
+### Example Usage
+
+```fsharp
+open FSharp.Finance.Personal.EquipmentFinance
+
+let loanTerms = {
+    Principal = 1000000L<Cent> // $10,000
+    InterestRate = Interest.Rate.Annual (Percent 6.0m)
+    TermMonths = 36
+    MonthlyPayment = None
+    EquipmentDescription = "Manufacturing Equipment"
+    EquipmentCost = 1000000L<Cent>
+    DownPayment = 200000L<Cent>
+    ResidualValue = 100000L<Cent>
+}
+
+let analysis = Loan.analyzeLoan loanTerms startDate
+// Returns comprehensive loan analysis including depreciation
+```
+
+## Equipment Leases
+
+### Lease Types Supported
+
+- **Operating Lease**: Off-balance-sheet, lessor retains ownership
+- **Finance Lease**: On-balance-sheet, lessee assumes ownership risks
+- **Capital Lease**: Similar to finance lease under older standards
+
+### Example Usage
+
+```fsharp
+open FSharp.Finance.Personal.EquipmentFinance
+
+let leaseTerms = {
+    EquipmentDescription = "Manufacturing Equipment"
+    FairMarketValue = 1000000L<Cent>
+    TermMonths = 36
+    LeaseType = Lease.LeaseType.FinanceLease
+    PaymentFrequency = Lease.PaymentFrequency.Monthly
+    LeasePayment = 30000L<Cent>
+    UpfrontPayment = 100000L<Cent>
+    ResidualValue = 200000L<Cent>
+    PurchaseOption = Some 200000L<Cent>
+    ImplicitRate = Interest.Rate.Annual (Percent 5.0m)
+}
+
+let analysis = Lease.analyzeLeaseVsBuy leaseTerms startDate
+// Returns lease vs buy analysis with depreciation comparison
+```
+
+### Key Features
+
+- Multiple payment frequencies (monthly, quarterly, etc.)
+- Present value calculations
+- Lease vs. buy analysis with depreciation integration
+- Support for purchase options
+
+## Common Features
+
+### Shared Utilities
+
+The `DepreciationCommon` module provides:
+
+- **Rounding utilities**: Consistent midpoint-away-from-zero rounding
+- **Validation functions**: Input validation for amounts and percentages
+- **Calculation helpers**: Common depreciation calculations
+- **Educational disclaimers**: Standardized disclaimer text
+
+### Integration
+
+All modules integrate seamlessly with the existing FSharp.Finance.Personal library:
+
+- Uses `int64<Cent>` for monetary values
+- Integrates with `Interest.Rate` and `Percent` types
+- Uses `DateDay.Date` for date handling
+- Follows existing functional programming patterns
+
+## Superseded PRs
+
+This implementation consolidates and supersedes:
+
+- **PR #5**: "Implement initial Equipment Finance & Leasing scaffolding"
+- **PR #9**: "WIP depreciation restructuring adding UK Capital Allowances"
+
+The consolidated implementation provides:
+
+- Consistent namespacing as specified in requirements
+- Proper module organization and compilation order
+- Comprehensive functionality from both PRs
+- Enhanced documentation and examples
+- Standardized coding patterns
+
+## Testing
+
+Comprehensive test suites are provided for all modules:
+
+- `DepreciationCommonTests.fs`: Tests for shared utilities
+- `USMacrsTests.fs`: Tests for US MACRS calculations
+- `UKCapitalAllowancesTests.fs`: Tests for UK Capital Allowances
+- `EquipmentLoanTests.fs`: Tests for loan calculations
+- `EquipmentLeaseTests.fs`: Tests for lease calculations
+
+## Future Enhancements
+
+Potential areas for expansion:
+
+- Additional depreciation methods (e.g., declining balance)
+- More sophisticated lease vs. buy NPV analysis
+- Integration with tax calculation modules
+- Support for partial-year conventions
+- Multiple asset management capabilities
+
+---
+
+**Note**: This documentation describes the consolidated Equipment Finance implementation that supersedes PRs #5 and #9, providing a unified and comprehensive solution for equipment finance analysis.

--- a/docs/EquipmentFinanceExamples.fsx
+++ b/docs/EquipmentFinanceExamples.fsx
@@ -30,7 +30,7 @@ printfn "=== US MACRS: Computer Equipment (5-Year) ==="
 open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
 
 let computer = {
-    CostBasis = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+    CostBasis = 10000_00L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
     PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
     PropertyClass = Types.AssetClass.FiveYear
     Convention = Types.Convention.HalfYear

--- a/docs/EquipmentFinanceExamples.fsx
+++ b/docs/EquipmentFinanceExamples.fsx
@@ -1,0 +1,230 @@
+(**
+# Equipment Finance Examples
+
+This script demonstrates the usage of the Equipment Finance modules
+that consolidate and supersede PRs #5 and #9.
+
+## Disclaimer
+
+These examples are for educational and analytical purposes only.
+They are NOT tax advice and should not be used for actual tax calculations
+without validation by qualified tax professionals.
+*)
+
+// Note: These examples show the API usage. 
+// In a real scenario, you would reference the compiled library:
+// #r "FSharp.Finance.Personal.dll"
+
+(**
+## US MACRS Depreciation Examples
+
+### Example 1: Computer Equipment (5-Year Property)
+
+A computer system costing $10,000, classified as 5-year property.
+*)
+
+printfn "=== US MACRS: Computer Equipment (5-Year) ==="
+
+// This would work once the library compiles:
+(*
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
+
+let computer = {
+    CostBasis = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+    PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+    PropertyClass = Types.AssetClass.FiveYear
+    Convention = Types.Convention.HalfYear
+}
+
+printfn "Cost: $%.2f (5-year property)" (float computer.CostBasis / 100.0)
+printfn ""
+
+let computerSchedule = Calculations.generateSchedule computer
+
+printfn "Year\tRate\t\tDepreciation\tAccumulated\tBook Value"
+computerSchedule 
+|> List.iter (fun year ->
+    printfn "%d\t%.2f%%\t\t$%.2f\t\t$%.2f\t\t$%.2f" 
+        year.Year 
+        (year.DepreciationRate * 100m)
+        (float year.DepreciationAmount / 100.0)
+        (float year.AccumulatedDepreciation / 100.0)
+        (float year.BookValue / 100.0))
+*)
+
+printfn "Cost: $10,000.00 (5-year property)"
+printfn ""
+printfn "Year\tRate\t\tDepreciation\tAccumulated\tBook Value"
+printfn "1\t20.00%%\t\t$2,000.00\t$2,000.00\t$8,000.00"
+printfn "2\t32.00%%\t\t$3,200.00\t$5,200.00\t$4,800.00"
+printfn "3\t19.20%%\t\t$1,920.00\t$7,120.00\t$2,880.00"
+printfn "4\t11.52%%\t\t$1,152.00\t$8,272.00\t$1,728.00"
+printfn "5\t11.52%%\t\t$1,152.00\t$9,424.00\t$576.00"
+printfn "6\t5.76%%\t\t$576.00\t\t$10,000.00\t$0.00"
+
+(**
+### Example 2: Office Furniture (7-Year Property)
+
+Office furniture costing $5,000, classified as 7-year property.
+*)
+
+printfn "\n=== US MACRS: Office Furniture (7-Year) ==="
+
+printfn "Cost: $5,000.00 (7-year property)"
+printfn ""
+printfn "Year\tRate\t\tDepreciation\tAccumulated\tBook Value"
+printfn "1\t14.29%%\t\t$714.50\t\t$714.50\t\t$4,285.50"
+printfn "2\t24.49%%\t\t$1,224.50\t$1,939.00\t$3,061.00"
+printfn "3\t17.49%%\t\t$874.50\t\t$2,813.50\t$2,186.50"
+printfn "4\t12.49%%\t\t$624.50\t\t$3,438.00\t$1,562.00"
+printfn "5\t8.93%%\t\t$446.50\t\t$3,884.50\t$1,115.50"
+printfn "6\t8.92%%\t\t$446.00\t\t$4,330.50\t$669.50"
+printfn "7\t8.93%%\t\t$446.50\t\t$4,777.00\t$223.00"
+printfn "8\t4.46%%\t\t$223.00\t\t$5,000.00\t$0.00"
+
+(**
+## UK Capital Allowances Examples
+
+### Example 1: Machinery in Main Pool (Small Asset)
+
+A small piece of manufacturing equipment costing £25,000 in the main pool.
+This will be fully claimed via AIA in year 1.
+*)
+
+printfn "\n=== UK Capital Allowances: Small Machinery ==="
+
+printfn "Cost: £25,000 in main pool"
+printfn ""
+printfn "Year\tAIA\t\tWDA\t\tTotal\t\tPool EOY"
+printfn "1\t£25,000\t\t£0\t\t£25,000\t\t£0"
+
+(**
+### Example 2: Large Equipment in Main Pool
+
+A large piece of equipment costing £150,000 in the main pool.
+This exceeds the AIA limit, so will use both AIA and WDA.
+*)
+
+printfn "\n=== UK Capital Allowances: Large Equipment ==="
+
+printfn "Cost: £150,000 in main pool"
+printfn "AIA limit: £100,000"
+printfn ""
+printfn "Year\tAIA\t\tWDA\t\tTotal\t\tPool EOY"
+printfn "1\t£100,000\t£9,000\t\t£109,000\t£41,000"    // AIA £100k, WDA 18% of remaining £50k
+printfn "2\t£0\t\t£7,380\t\t£7,380\t\t£33,620"        // WDA 18% of £41k
+printfn "3\t£0\t\t£6,052\t\t£6,052\t\t£27,568"        // WDA 18% of £33,620
+printfn "4\t£0\t\t£4,962\t\t£4,962\t\t£22,606"        // WDA 18% of £27,568
+
+(**
+### Example 3: Vehicle in Special Rate Pool
+
+A company vehicle costing £35,000 in the special rate pool (6% WDA).
+*)
+
+printfn "\n=== UK Capital Allowances: Vehicle (Special Rate Pool) ==="
+
+printfn "Cost: £35,000 in special rate pool (6%% WDA)"
+printfn "AIA limit: £25,000"
+printfn ""
+printfn "Year\tAIA\t\tWDA\t\tTotal\t\tPool EOY"
+printfn "1\t£25,000\t\t£600\t\t£25,600\t\t£9,400"      // AIA £25k, WDA 6% of remaining £10k
+printfn "2\t£0\t\t£564\t\t£564\t\t£8,836"             // WDA 6% of £9,400
+printfn "3\t£0\t\t£530\t\t£530\t\t£8,306"             // WDA 6% of £8,836
+
+(**
+## Equipment Loan Examples
+
+### Example 1: Basic Equipment Loan
+
+A loan for manufacturing equipment with a 6% annual interest rate.
+*)
+
+printfn "\n=== Equipment Loan: Manufacturing Equipment ==="
+
+printfn "Principal: $10,000"
+printfn "Interest Rate: 6%% annual"
+printfn "Term: 36 months"
+printfn "Down Payment: $2,000"
+printfn ""
+printfn "Monthly Payment: ~$304.22"
+printfn "Total Payments: $10,951.92"
+printfn "Total Interest: $951.92"
+
+(**
+### Example 2: Equipment Lease vs Buy Analysis
+
+Comparing leasing vs buying manufacturing equipment.
+*)
+
+printfn "\n=== Equipment Lease vs Buy Analysis ==="
+
+printfn "Equipment Fair Market Value: $10,000"
+printfn "Lease Term: 36 months"
+printfn "Monthly Lease Payment: $300"
+printfn "Residual Value: $2,000"
+printfn "Purchase Option: $2,000"
+printfn ""
+printfn "Lease Analysis:"
+printfn "  Total Lease Payments: $10,800"
+printfn "  Total Cost (with purchase): $12,800"
+printfn "  Present Value of Payments: ~$10,200"
+printfn ""
+printfn "Purchase Analysis:"
+printfn "  Purchase Price: $10,000"
+printfn "  5-Year MACRS Depreciation Available"
+printfn "  Year 1 Depreciation: $2,000 (20%%)"
+
+(**
+## Integration Examples
+
+### Example 1: Loan with Depreciation Analysis
+
+Showing how equipment loans integrate with depreciation calculations.
+*)
+
+printfn "\n=== Loan with Depreciation Analysis ==="
+
+printfn "Equipment: Manufacturing Equipment ($10,000)"
+printfn "Loan: $8,000 at 6%% for 36 months"
+printfn "Classification: 7-year MACRS property"
+printfn ""
+printfn "Financial Analysis:"
+printfn "  Monthly Payment: $243.38"
+printfn "  Total Interest: $761.68"
+printfn ""
+printfn "Tax Analysis (Year 1):"
+printfn "  MACRS Depreciation: $1,429 (14.29%%)"
+printfn "  Interest Deduction: ~$400"
+
+(**
+## Summary
+
+This script demonstrates the key features of the consolidated Equipment Finance modules:
+
+### US MACRS Depreciation
+- Different asset classes with varying recovery periods
+- Half-year convention application
+- Percentage-based depreciation schedules
+- Complete depreciation over the recovery period
+
+### UK Capital Allowances
+- Different treatment for main pool (18%) vs special rate pool (6%)
+- Annual Investment Allowance application in year 1
+- Writing Down Allowances for remaining value
+- Midpoint-away-from-zero rounding
+
+### Equipment Financing
+- Comprehensive loan calculations with amortization schedules
+- Lease analysis with multiple lease types
+- Lease vs buy comparison capabilities
+- Integration with depreciation calculations for complete analysis
+
+All modules provide educational implementations of complex financial and tax
+calculations and should be validated with professionals for actual use.
+
+This implementation consolidates and supersedes PRs #5 and #9, providing a
+unified Equipment Finance solution with proper namespacing and structure.
+*)
+
+printfn "\n=== Examples completed ==="

--- a/docs/EquipmentFinanceExamples.fsx
+++ b/docs/EquipmentFinanceExamples.fsx
@@ -1,4 +1,15 @@
 (**
+---
+title: Equipment Finance Examples
+category: Examples
+categoryindex: 2
+index: 5
+description: Examples of equipment finance calculations
+keywords: equipment finance loan lease depreciation MACRS capital allowances
+---
+*)
+
+(**
 # Equipment Finance Examples
 
 This script demonstrates the usage of the Equipment Finance modules
@@ -11,9 +22,16 @@ They are NOT tax advice and should not be used for actual tax calculations
 without validation by qualified tax professionals.
 *)
 
-// Note: These examples show the API usage. 
-// In a real scenario, you would reference the compiled library:
-// #r "FSharp.Finance.Personal.dll"
+// Once a release of FSharp.Finance.Personal including the EquipmentFinance modules is
+// published, this can become: #r "nuget:FSharp.Finance.Personal"
+// Until then, build the library first (dotnet build src) and reference it directly:
+#r "../src/bin/Debug/netstandard2.1/FSharp.Finance.Personal.dll"
+
+open FSharp.Finance.Personal
+open FSharp.Finance.Personal.Calculation
+open FSharp.Finance.Personal.EquipmentFinance
+
+let money (c: int64<Cent>) = Cent.toDecimal c
 
 (**
 ## US MACRS Depreciation Examples
@@ -23,157 +41,255 @@ without validation by qualified tax professionals.
 A computer system costing $10,000, classified as 5-year property.
 *)
 
+module MACRS = FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS.Calculations
+module MacrsTypes = FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS.Types
+
 printfn "=== US MACRS: Computer Equipment (5-Year) ==="
 
-// This would work once the library compiles:
-(*
-open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
-
-let computer = {
-    CostBasis = 10000_00L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
-    PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
-    PropertyClass = Types.AssetClass.FiveYear
-    Convention = Types.Convention.HalfYear
+let computer: MacrsTypes.MacrsAsset = {
+    CostBasis = 10000_00L<Cent> // $10,000
+    PlacedInServiceDate = DateDay.Date(2024, 1, 1)
+    PropertyClass = MacrsTypes.AssetClass.FiveYear
+    Convention = MacrsTypes.Convention.HalfYear
 }
 
-printfn "Cost: $%.2f (5-year property)" (float computer.CostBasis / 100.0)
+printfn "Cost: $%.2f (5-year property)" (money computer.CostBasis)
 printfn ""
-
-let computerSchedule = Calculations.generateSchedule computer
-
 printfn "Year\tRate\t\tDepreciation\tAccumulated\tBook Value"
-computerSchedule 
+
+MACRS.generateSchedule computer
 |> List.iter (fun year ->
-    printfn "%d\t%.2f%%\t\t$%.2f\t\t$%.2f\t\t$%.2f" 
-        year.Year 
+    printfn "%d\t%.2f%%\t\t$%.2f\t\t$%.2f\t\t$%.2f"
+        year.Year
         (year.DepreciationRate * 100m)
-        (float year.DepreciationAmount / 100.0)
-        (float year.AccumulatedDepreciation / 100.0)
-        (float year.BookValue / 100.0))
-*)
-
-printfn "Cost: $10,000.00 (5-year property)"
-printfn ""
-printfn "Year\tRate\t\tDepreciation\tAccumulated\tBook Value"
-printfn "1\t20.00%%\t\t$2,000.00\t$2,000.00\t$8,000.00"
-printfn "2\t32.00%%\t\t$3,200.00\t$5,200.00\t$4,800.00"
-printfn "3\t19.20%%\t\t$1,920.00\t$7,120.00\t$2,880.00"
-printfn "4\t11.52%%\t\t$1,152.00\t$8,272.00\t$1,728.00"
-printfn "5\t11.52%%\t\t$1,152.00\t$9,424.00\t$576.00"
-printfn "6\t5.76%%\t\t$576.00\t\t$10,000.00\t$0.00"
+        (money year.DepreciationAmount)
+        (money year.AccumulatedDepreciation)
+        (money year.BookValue))
 
 (**
 ### Example 2: Office Furniture (7-Year Property)
 
-Office furniture costing $5,000, classified as 7-year property.
+Office furniture costing $5,000, classified as 7-year property. Here the asset class is
+derived from the description with `tryClassifyAsset`.
 *)
 
 printfn "\n=== US MACRS: Office Furniture (7-Year) ==="
 
-printfn "Cost: $5,000.00 (7-year property)"
+let furnitureClass =
+    MACRS.tryClassifyAsset "office furniture"
+    |> Option.defaultValue MacrsTypes.AssetClass.FiveYear
+
+let furniture: MacrsTypes.MacrsAsset = {
+    CostBasis = 5000_00L<Cent> // $5,000
+    PlacedInServiceDate = DateDay.Date(2024, 1, 1)
+    PropertyClass = furnitureClass
+    Convention = MacrsTypes.Convention.HalfYear
+}
+
+printfn "Cost: $%.2f (classified as %A)" (money furniture.CostBasis) furniture.PropertyClass
 printfn ""
 printfn "Year\tRate\t\tDepreciation\tAccumulated\tBook Value"
-printfn "1\t14.29%%\t\t$714.50\t\t$714.50\t\t$4,285.50"
-printfn "2\t24.49%%\t\t$1,224.50\t$1,939.00\t$3,061.00"
-printfn "3\t17.49%%\t\t$874.50\t\t$2,813.50\t$2,186.50"
-printfn "4\t12.49%%\t\t$624.50\t\t$3,438.00\t$1,562.00"
-printfn "5\t8.93%%\t\t$446.50\t\t$3,884.50\t$1,115.50"
-printfn "6\t8.92%%\t\t$446.00\t\t$4,330.50\t$669.50"
-printfn "7\t8.93%%\t\t$446.50\t\t$4,777.00\t$223.00"
-printfn "8\t4.46%%\t\t$223.00\t\t$5,000.00\t$0.00"
+
+MACRS.generateSchedule furniture
+|> List.iter (fun year ->
+    printfn "%d\t%.2f%%\t\t$%.2f\t\t$%.2f\t\t$%.2f"
+        year.Year
+        (year.DepreciationRate * 100m)
+        (money year.DepreciationAmount)
+        (money year.AccumulatedDepreciation)
+        (money year.BookValue))
+
+(**
+Note: real property is out of scope for this simplified MACRS module - descriptions such
+as "building" are rejected with an error because buildings are 27.5/39-year straight-line
+property, not equipment.
+*)
 
 (**
 ## UK Capital Allowances Examples
 
 ### Example 1: Machinery in Main Pool (Small Asset)
 
-A small piece of manufacturing equipment costing £25,000 in the main pool.
-This will be fully claimed via AIA in year 1.
+Manufacturing equipment costing 25,000 GBP in the main pool.
+This is fully claimed via the Annual Investment Allowance in year 1.
 *)
+
+module UKCA = FSharp.Finance.Personal.EquipmentFinance.Depreciation.UK_CapitalAllowances.Calculations
+module UKCATypes = FSharp.Finance.Personal.EquipmentFinance.Depreciation.UK_CapitalAllowances.Types
+
+let printAllowances (schedule: UKCATypes.AllowanceSchedule) =
+    printfn "Year\tAIA\t\tWDA\t\tTotal\t\tPool EOY"
+    schedule.Years
+    |> List.iter (fun year ->
+        printfn "%d\t£%.2f\t£%.2f\t£%.2f\t£%.2f"
+            year.Year
+            (money year.AnnualInvestmentAllowance)
+            (money year.WritingDownAllowance)
+            (money year.TotalAllowances)
+            (money year.PoolValueEndOfYear))
+    if schedule.UnclaimedPool > 0L<Cent> then
+        printfn "Unclaimed pool after final year: £%.2f" (money schedule.UnclaimedPool)
 
 printfn "\n=== UK Capital Allowances: Small Machinery ==="
 
-printfn "Cost: £25,000 in main pool"
+let smallMachinery: UKCATypes.Expenditure = {
+    Amount = 25_000_00L<Cent>
+    Pool = UKCATypes.Pool.Main
+    Description = "Manufacturing equipment"
+}
+
+printfn "Cost: £%.2f in main pool" (money smallMachinery.Amount)
 printfn ""
-printfn "Year\tAIA\t\tWDA\t\tTotal\t\tPool EOY"
-printfn "1\t£25,000\t\t£0\t\t£25,000\t\t£0"
+UKCA.scheduleDefault smallMachinery |> printAllowances
 
 (**
 ### Example 2: Large Equipment in Main Pool
 
-A large piece of equipment costing £150,000 in the main pool.
-This exceeds the AIA limit, so will use both AIA and WDA.
+Equipment costing 150,000 GBP against a reduced AIA limit of 100,000 GBP, so it uses both
+AIA and writing down allowances. Any pool value left when the calculation stops at
+`MaxYears` is reported as `UnclaimedPool` rather than silently dropped.
 *)
 
 printfn "\n=== UK Capital Allowances: Large Equipment ==="
 
-printfn "Cost: £150,000 in main pool"
-printfn "AIA limit: £100,000"
+let largeEquipment: UKCATypes.Expenditure = {
+    Amount = 150_000_00L<Cent>
+    Pool = UKCATypes.Pool.Main
+    Description = "Production line"
+}
+
+let largeConfig = {
+    UKCATypes.Default with
+        AnnualInvestmentAllowanceLimit = 100_000_00L<Cent>
+        MaxYears = 4
+}
+
+printfn "Cost: £%.2f in main pool, AIA limit £%.2f" (money largeEquipment.Amount) (money largeConfig.AnnualInvestmentAllowanceLimit)
 printfn ""
-printfn "Year\tAIA\t\tWDA\t\tTotal\t\tPool EOY"
-printfn "1\t£100,000\t£9,000\t\t£109,000\t£41,000"    // AIA £100k, WDA 18% of remaining £50k
-printfn "2\t£0\t\t£7,380\t\t£7,380\t\t£33,620"        // WDA 18% of £41k
-printfn "3\t£0\t\t£6,052\t\t£6,052\t\t£27,568"        // WDA 18% of £33,620
-printfn "4\t£0\t\t£4,962\t\t£4,962\t\t£22,606"        // WDA 18% of £27,568
+UKCA.generateSchedule largeConfig largeEquipment |> printAllowances
 
 (**
 ### Example 3: Vehicle in Special Rate Pool
 
-A company vehicle costing £35,000 in the special rate pool (6% WDA).
+A company vehicle costing 35,000 GBP in the special rate pool (6% WDA) against a reduced
+AIA limit of 25,000 GBP. When the pool balance drops to 1,000 GBP or below, the HMRC small
+pools allowance writes off the remainder in full.
 *)
 
 printfn "\n=== UK Capital Allowances: Vehicle (Special Rate Pool) ==="
 
-printfn "Cost: £35,000 in special rate pool (6%% WDA)"
-printfn "AIA limit: £25,000"
+let vehicle: UKCATypes.Expenditure = {
+    Amount = 35_000_00L<Cent>
+    Pool = UKCATypes.Pool.SpecialRate
+    Description = "Company vehicle"
+}
+
+let vehicleConfig = {
+    UKCATypes.Default with
+        AnnualInvestmentAllowanceLimit = 25_000_00L<Cent>
+        MaxYears = 3
+}
+
+printfn "Cost: £%.2f in special rate pool (6%% WDA), AIA limit £%.2f" (money vehicle.Amount) (money vehicleConfig.AnnualInvestmentAllowanceLimit)
 printfn ""
-printfn "Year\tAIA\t\tWDA\t\tTotal\t\tPool EOY"
-printfn "1\t£25,000\t\t£600\t\t£25,600\t\t£9,400"      // AIA £25k, WDA 6% of remaining £10k
-printfn "2\t£0\t\t£564\t\t£564\t\t£8,836"             // WDA 6% of £9,400
-printfn "3\t£0\t\t£530\t\t£530\t\t£8,306"             // WDA 6% of £8,836
+UKCA.generateSchedule vehicleConfig vehicle |> printAllowances
 
 (**
 ## Equipment Loan Examples
 
 ### Example 1: Basic Equipment Loan
 
-A loan for manufacturing equipment with a 6% annual interest rate.
+A loan for manufacturing equipment with a 6% annual interest rate and a monthly service fee.
 *)
 
 printfn "\n=== Equipment Loan: Manufacturing Equipment ==="
 
-printfn "Principal: $10,000"
-printfn "Interest Rate: 6%% annual"
-printfn "Term: 36 months"
-printfn "Down Payment: $2,000"
+let loanTerms: Loan.EquipmentLoanTerms = {
+    Principal = 10000_00L<Cent> // $10,000 financed
+    InterestRate = Interest.Rate.Annual (Percent 6.0m)
+    TermMonths = 36
+    MonthlyPayment = None // calculated
+    MonthlyFee = Some 5_00L<Cent> // $5/month service fee
+    EquipmentDescription = "Manufacturing equipment"
+    EquipmentCost = 12000_00L<Cent>
+    DownPayment = 2000_00L<Cent>
+    ResidualValue = 0L<Cent>
+}
+
+let loanDetails = Loan.calculatePaymentDetails loanTerms
+
+printfn "Principal: $%.2f" (money loanTerms.Principal)
+printfn "Interest Rate: %O nominal annual" loanDetails.NominalAnnualRate
+printfn "Term: %d months" loanTerms.TermMonths
+printfn "Down Payment: $%.2f" (money loanTerms.DownPayment)
 printfn ""
-printfn "Monthly Payment: ~$304.22"
-printfn "Total Payments: $10,951.92"
-printfn "Total Interest: $951.92"
+printfn "Monthly Payment: $%.2f (+ $%.2f fee)" (money loanDetails.MonthlyPayment) (money (loanTerms.MonthlyFee |> Option.defaultValue 0L<Cent>))
+printfn "Total Payments: $%.2f" (money loanDetails.TotalPayments)
+printfn "Total Interest: $%.2f" (money loanDetails.TotalInterest)
+printfn "Total Fees: $%.2f" (money loanDetails.TotalFees)
+
+let loanSchedule = Loan.generateAmortizationSchedule loanTerms (DateDay.Date(2024, 1, 1))
+
+printfn ""
+printfn "First three payments and the final payment:"
+printfn "#\tPayment\t\tPrincipal\tInterest\tFee\tBalance"
+
+Array.append (loanSchedule |> Array.take 3) [| loanSchedule |> Array.last |]
+|> Array.iter (fun item ->
+    printfn "%d\t$%.2f\t\t$%.2f\t\t$%.2f\t\t$%.2f\t$%.2f"
+        item.PaymentNumber
+        (money item.PaymentAmount)
+        (money item.PrincipalPayment)
+        (money item.InterestPayment)
+        (money item.FeePayment)
+        (money item.RemainingBalance))
 
 (**
 ### Example 2: Equipment Lease vs Buy Analysis
 
-Comparing leasing vs buying manufacturing equipment.
+Comparing leasing vs buying manufacturing equipment. Equipment leases are usually paid in
+advance (at the start of each period), and the analysis discounts both alternatives at a
+supplied discount rate to compute the net advantage to leasing.
 *)
 
 printfn "\n=== Equipment Lease vs Buy Analysis ==="
 
-printfn "Equipment Fair Market Value: $10,000"
-printfn "Lease Term: 36 months"
-printfn "Monthly Lease Payment: $300"
-printfn "Residual Value: $2,000"
-printfn "Purchase Option: $2,000"
+let leaseTerms: Lease.EquipmentLeaseTerms = {
+    EquipmentDescription = "Manufacturing equipment"
+    FairMarketValue = 10000_00L<Cent> // $10,000
+    TermMonths = 36
+    LeaseType = Lease.LeaseType.FinanceLease
+    PaymentFrequency = Lease.PaymentFrequency.Monthly
+    PaymentTiming = Lease.PaymentTiming.InAdvance
+    LeasePayment = 0L<Cent> // calculated
+    PeriodicFee = None
+    UpfrontPayment = 1000_00L<Cent>
+    ResidualValue = 2000_00L<Cent>
+    PurchaseOption = Some 2000_00L<Cent>
+    ImplicitRate = Interest.Rate.Annual (Percent 5.0m)
+}
+
+let discountRate = Percent 8.0m
+let leaseAnalysis = Lease.analyzeLeaseVsBuy leaseTerms (DateDay.Date(2024, 1, 1)) discountRate
+let leaseDetails = leaseAnalysis.LeaseDetails
+
+printfn "Equipment Fair Market Value: $%.2f" (money leaseTerms.FairMarketValue)
+printfn "Lease Term: %d months, paid in advance" leaseTerms.TermMonths
+printfn "Residual Value: $%.2f" (money leaseTerms.ResidualValue)
+printfn "Purchase Option: $%.2f" (money (leaseTerms.PurchaseOption |> Option.defaultValue 0L<Cent>))
 printfn ""
 printfn "Lease Analysis:"
-printfn "  Total Lease Payments: $10,800"
-printfn "  Total Cost (with purchase): $12,800"
-printfn "  Present Value of Payments: ~$10,200"
+printfn "  Monthly Lease Payment: $%.2f" (money leaseDetails.LeasePayment)
+printfn "  Total Lease Payments: $%.2f" (money leaseDetails.TotalPayments)
+printfn "  Total Cost (with purchase): $%.2f" (money leaseDetails.TotalCost)
+printfn "  Present Value of Payments: $%.2f" (money leaseDetails.PresentValue)
+printfn "  Net Advantage to Leasing (at %O discount): $%.2f" discountRate (money leaseAnalysis.NetAdvantageToLeasing)
 printfn ""
 printfn "Purchase Analysis:"
-printfn "  Purchase Price: $10,000"
-printfn "  5-Year MACRS Depreciation Available"
-printfn "  Year 1 Depreciation: $2,000 (20%%)"
+printfn "  Purchase Price: $%.2f" (money leaseTerms.FairMarketValue)
+
+let purchaseYear1 = leaseAnalysis.PurchaseDepreciation |> List.head
+printfn "  Year 1 MACRS Depreciation: $%.2f (%.2f%%)" (money purchaseYear1.DepreciationAmount) (purchaseYear1.DepreciationRate * 100m)
 
 (**
 ## Integration Examples
@@ -185,17 +301,39 @@ Showing how equipment loans integrate with depreciation calculations.
 
 printfn "\n=== Loan with Depreciation Analysis ==="
 
-printfn "Equipment: Manufacturing Equipment ($10,000)"
-printfn "Loan: $8,000 at 6%% for 36 months"
-printfn "Classification: 7-year MACRS property"
+let integratedTerms: Loan.EquipmentLoanTerms = {
+    Principal = 8000_00L<Cent> // $8,000 financed
+    InterestRate = Interest.Rate.Annual (Percent 6.0m)
+    TermMonths = 36
+    MonthlyPayment = None
+    MonthlyFee = None
+    EquipmentDescription = "Manufacturing equipment"
+    EquipmentCost = 10000_00L<Cent>
+    DownPayment = 2000_00L<Cent>
+    ResidualValue = 0L<Cent>
+}
+
+let loanAnalysis = Loan.analyzeLoan integratedTerms (DateDay.Date(2024, 1, 1)) (Percent 8.0m)
+
+printfn "Equipment: %s ($%.2f)" integratedTerms.EquipmentDescription (money integratedTerms.EquipmentCost)
+printfn "Loan: $%.2f at %O for %d months" (money integratedTerms.Principal) loanAnalysis.PaymentDetails.NominalAnnualRate integratedTerms.TermMonths
+printfn "Classification assumed: %b" loanAnalysis.AssetClassAssumed
 printfn ""
 printfn "Financial Analysis:"
-printfn "  Monthly Payment: $243.38"
-printfn "  Total Interest: $761.68"
+printfn "  Monthly Payment: $%.2f" (money loanAnalysis.PaymentDetails.MonthlyPayment)
+printfn "  Total Interest: $%.2f" (money loanAnalysis.PaymentDetails.TotalInterest)
+printfn "  NPV of loan cash flows at 8%%: $%.2f" (money loanAnalysis.NetPresentValue)
 printfn ""
+
+let year1Depreciation = loanAnalysis.DepreciationSchedule |> List.head
+let year1Interest =
+    loanAnalysis.AmortizationSchedule
+    |> Array.filter (fun item -> item.PaymentNumber <= 12)
+    |> Array.sumBy (fun item -> item.InterestPayment)
+
 printfn "Tax Analysis (Year 1):"
-printfn "  MACRS Depreciation: $1,429 (14.29%%)"
-printfn "  Interest Deduction: ~$400"
+printfn "  MACRS Depreciation: $%.2f (%.2f%%)" (money year1Depreciation.DepreciationAmount) (year1Depreciation.DepreciationRate * 100m)
+printfn "  Interest Paid: $%.2f" (money year1Interest)
 
 (**
 ## Summary
@@ -205,19 +343,20 @@ This script demonstrates the key features of the consolidated Equipment Finance 
 ### US MACRS Depreciation
 - Different asset classes with varying recovery periods
 - Half-year convention application
-- Percentage-based depreciation schedules
+- IRS Table A-1 percentage schedules
 - Complete depreciation over the recovery period
+- Keyword-based classification that rejects unsupported real property
 
 ### UK Capital Allowances
 - Different treatment for main pool (18%) vs special rate pool (6%)
 - Annual Investment Allowance application in year 1
 - Writing Down Allowances for remaining value
-- Midpoint-away-from-zero rounding
+- HMRC small pools allowance and explicit unclaimed pool reporting
 
 ### Equipment Financing
-- Comprehensive loan calculations with amortization schedules
-- Lease analysis with multiple lease types
-- Lease vs buy comparison capabilities
+- Loan calculations with amortization schedules, residual balloons and recurring fees
+- Lease schedules honouring the contractual rental, in advance or in arrears
+- Lease vs buy comparison with net advantage to leasing at a supplied discount rate
 - Integration with depreciation calculations for complete analysis
 
 All modules provide educational implementations of complex financial and tax

--- a/io/out/GeneratedDate.html
+++ b/io/out/GeneratedDate.html
@@ -1,1 +1,1 @@
-<p>Generated: <i>2025-06-05 15:01:19 +01:00</i> using library version: <i>2.5.5</i></p>
+<p>Generated: <i>2025-09-10 16:27:37 +00:00</i> using library version: <i>2.5.5</i></p>

--- a/io/out/GeneratedDate.html
+++ b/io/out/GeneratedDate.html
@@ -1,1 +1,1 @@
-<p>Generated: <i>2025-09-10 16:27:37 +00:00</i> using library version: <i>2.5.5</i></p>
+<p>Generated: <i>2025-06-05 15:01:19 +01:00</i> using library version: <i>2.5.5</i></p>

--- a/src/Amortisation.fs
+++ b/src/Amortisation.fs
@@ -17,7 +17,6 @@ module Amortisation =
         | SettlementDay
 
     /// the day of the amortisation schedule, which can be a normal day, evaluation day or settlement day
-    [<Struct>]
     module OffsetDayType =
         /// HTML formatting to display the amortisation day in a readable format
         let toHtml (offsetDay: int<OffsetDay>) offsetDayType =

--- a/src/EquipmentFinance/Depreciation/DepreciationCommon.fs
+++ b/src/EquipmentFinance/Depreciation/DepreciationCommon.fs
@@ -27,7 +27,11 @@ module DepreciationCommon =
         Depreciation: int64<Cent>
         Accumulated: int64<Cent>
         BookValue: int64<Cent>
-        Method: string   // "SL", "DB", or "DB->SL"
+        /// "SL", "DB", "DB (final adjustment)", or "DB->SL".
+        /// Pure declining balance never reaches the salvage value by itself, so its final
+        /// period is a plug that lands exactly on salvage; that period is labelled
+        /// "DB (final adjustment)" to distinguish it from rate-based periods.
+        Method: string
     }
 
     /// Common validation utilities
@@ -171,6 +175,10 @@ module DepreciationCommon =
         /// switchToStraightLine: if true, permanently switches to SL once advantageous
         ///
         /// Rounding: Per-period depreciation is rounded to cents; final period adjusted for exact salvage.
+        ///
+        /// Note: without the straight-line switch, a declining balance never reaches the salvage
+        /// value by itself, so the final period is a plug (book value minus salvage) rather than a
+        /// rate-based amount; it is labelled "DB (final adjustment)" to make this explicit.
         let decliningBalance
             (cost: int64<Cent>)
             (salvage: int64<Cent>)
@@ -209,6 +217,10 @@ module DepreciationCommon =
                             (straightLineRemainderDec, true, "DB->SL")
                         elif switchToStraightLine && straightLineRemainderDec > decliningDec then
                             (straightLineRemainderDec, true, "DB->SL")
+                        elif isLast then
+                            // pure DB never lands on salvage by itself: the final period is a
+                            // plug to exactly reach the salvage value, labelled distinctly
+                            (decliningDec, false, "DB (final adjustment)")
                         else
                             (decliningDec, false, "DB")
 

--- a/src/EquipmentFinance/Depreciation/DepreciationCommon.fs
+++ b/src/EquipmentFinance/Depreciation/DepreciationCommon.fs
@@ -21,21 +21,6 @@ module DepreciationCommon =
         PlacedInServiceDate: DateDay.Date option
     }
 
-    /// Common rounding utilities for depreciation calculations
-    module Rounding =
-        
-        /// Rounds a decimal value to 2 decimal places using midpoint-away-from-zero
-        let roundCurrency (value: decimal) =
-            Math.Round(value, 2, MidpointRounding.AwayFromZero)
-        
-        /// Rounds a decimal value to specified decimal places using midpoint-away-from-zero
-        let roundToPlaces (places: int) (value: decimal) =
-            Math.Round(value, places, MidpointRounding.AwayFromZero)
-        
-        /// Rounds a percentage to 4 decimal places
-        let roundPercentage (value: decimal) =
-            Math.Round(value, 4, MidpointRounding.AwayFromZero)
-
     /// Common validation utilities
     module Validation =
         

--- a/src/EquipmentFinance/Depreciation/DepreciationCommon.fs
+++ b/src/EquipmentFinance/Depreciation/DepreciationCommon.fs
@@ -1,0 +1,94 @@
+namespace FSharp.Finance.Personal.EquipmentFinance.Depreciation
+
+open System
+open FSharp.Finance.Personal
+open FSharp.Finance.Personal.Calculation
+
+/// Common depreciation abstractions and utilities shared across depreciation modules.
+/// 
+/// This module provides common types, interfaces, and utility functions that can be
+/// used across different depreciation calculation methods (UK Capital Allowances,
+/// US MACRS, etc.).
+module DepreciationCommon =
+
+    /// Represents basic asset information
+    type AssetInfo = {
+        /// The original cost basis of the asset
+        CostBasis: int64<Cent>
+        /// Asset description
+        Description: string
+        /// Date asset was placed in service (optional)
+        PlacedInServiceDate: DateDay.Date option
+    }
+
+    /// Common rounding utilities for depreciation calculations
+    module Rounding =
+        
+        /// Rounds a decimal value to 2 decimal places using midpoint-away-from-zero
+        let roundCurrency (value: decimal) =
+            Math.Round(value, 2, MidpointRounding.AwayFromZero)
+        
+        /// Rounds a decimal value to specified decimal places using midpoint-away-from-zero
+        let roundToPlaces (places: int) (value: decimal) =
+            Math.Round(value, places, MidpointRounding.AwayFromZero)
+        
+        /// Rounds a percentage to 4 decimal places
+        let roundPercentage (value: decimal) =
+            Math.Round(value, 4, MidpointRounding.AwayFromZero)
+
+    /// Common validation utilities
+    module Validation =
+        
+        /// Validates that an amount is positive
+        let validatePositiveAmount (amount: int64<Cent>) (fieldName: string) =
+            if amount <= 0L<Cent> then
+                failwith $"{fieldName} must be positive, got {amount}"
+        
+        /// Validates that a percentage is between 0 and 1
+        let validatePercentage (percentage: decimal) (fieldName: string) =
+            if percentage < 0m || percentage > 1m then
+                failwith $"{fieldName} must be between 0 and 1, got {percentage}"
+        
+        /// Validates that a year count is positive
+        let validateYearCount (years: int) (fieldName: string) =
+            if years <= 0 then
+                failwith $"{fieldName} must be positive, got {years}"
+
+    /// Common calculation utilities
+    module Calculations =
+        
+        /// Calculates the remaining value after depreciation
+        let calculateRemainingValue (originalCost: int64<Cent>) (cumulativeDepreciation: int64<Cent>) =
+            originalCost - cumulativeDepreciation
+        
+        /// Applies a percentage rate to a base amount
+        let applyRate (baseAmount: int64<Cent>) (rate: decimal) =
+            let result = decimal baseAmount * rate
+            Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero) (result * 1m<Cent>)
+        
+        /// Ensures total depreciation does not exceed original cost
+        let capDepreciationAtCost (originalCost: int64<Cent>) (proposedDepreciation: int64<Cent>) (cumulativeDepreciation: int64<Cent>) =
+            let maxAllowable = originalCost - cumulativeDepreciation
+            min proposedDepreciation maxAllowable
+
+    /// Disclaimer text for educational use
+    module Disclaimers =
+        
+        /// Standard educational disclaimer for all depreciation modules
+        let EducationalDisclaimer = 
+            "IMPORTANT DISCLAIMER: This module is for educational and analytical purposes only. " +
+            "It is NOT tax advice and should not be used for actual tax calculations without " +
+            "validation by qualified tax professionals. The implementation includes several " +
+            "simplifications that may not reflect real-world tax scenarios."
+        
+        /// UK-specific disclaimer additions
+        let UKSpecificDisclaimer =
+            "This implementation is based on general UK capital allowances rules and may not " +
+            "reflect recent changes, special circumstances, or specific industry rules. " +
+            "Always consult HMRC guidance and qualified tax advisors."
+        
+        /// US-specific disclaimer additions
+        let USSpecificDisclaimer =
+            "This implementation is based on general US MACRS rules and may not reflect " +
+            "recent tax law changes, special circumstances, or state-specific rules. " +
+            "Always consult IRS publications and qualified tax professionals."

--- a/src/EquipmentFinance/Depreciation/DepreciationCommon.fs
+++ b/src/EquipmentFinance/Depreciation/DepreciationCommon.fs
@@ -1,4 +1,4 @@
-namespace FSharp.Finance.Personal.EquipmentFinance.Depreciation
+﻿namespace FSharp.Finance.Personal.EquipmentFinance.Depreciation
 
 open System
 open FSharp.Finance.Personal
@@ -19,6 +19,15 @@ module DepreciationCommon =
         Description: string
         /// Date asset was placed in service (optional)
         PlacedInServiceDate: DateDay.Date option
+    }
+
+    /// Per‑period depreciation result
+    type DepreciationPeriod = {
+        Period: int
+        Depreciation: int64<Cent>
+        Accumulated: int64<Cent>
+        BookValue: int64<Cent>
+        Method: string   // "SL", "DB", or "DB->SL"
     }
 
     /// Common validation utilities
@@ -55,6 +64,184 @@ module DepreciationCommon =
         let capDepreciationAtCost (originalCost: int64<Cent>) (proposedDepreciation: int64<Cent>) (cumulativeDepreciation: int64<Cent>) =
             let maxAllowable = originalCost - cumulativeDepreciation
             min proposedDepreciation maxAllowable
+
+        // Private validation helper
+        let private validateInputs (cost: int64<Cent>) (salvage: int64<Cent>) (life: int) =
+            if life <= 0 then invalidArg (nameof life) "Life must be > 0."
+            if cost <= 0L<Cent> then invalidArg (nameof cost) "Cost must be > 0."
+            if salvage < 0L<Cent> then invalidArg (nameof salvage) "Salvage must be >= 0."
+            if salvage >= cost then invalidArg (nameof salvage) "Salvage must be less than cost."
+
+        // Enforce final salvage exactly by reconstructing the last period if needed.
+        let private enforceSalvage (cost: int64<Cent>) (salvage: int64<Cent>) (schedule: DepreciationPeriod array) =
+            if schedule.Length = 0 then schedule
+            else
+                let lastIndex = schedule.Length - 1
+                let last = schedule[lastIndex]
+                if last.BookValue = salvage then schedule
+                else
+                    let life = schedule.Length
+                    let prevAccum, prevBookValue =
+                        if life = 1 then
+                            0L<Cent>, cost
+                        else
+                            let prev = schedule.[lastIndex - 1]
+                            prev.Accumulated, prev.BookValue
+                    let finalDepDec = Cent.toDecimal prevBookValue - Cent.toDecimal salvage
+                    let finalDep = Cent.fromDecimal finalDepDec
+                    let finalAccum = prevAccum + finalDep
+                    let adjustedLast = {
+                        last with
+                            Depreciation = finalDep
+                            Accumulated  = finalAccum
+                            BookValue    = salvage
+                    }
+                    let clone = Array.copy schedule
+                    clone[life-1] <- adjustedLast
+                    clone
+
+        /// Straight-line depreciation schedule.
+        /// cost      : original asset cost (in cents)
+        /// salvage   : target final book value (in cents)
+        /// life      : number of periods
+        /// Returns an array of period records (1-based Period index).
+        /// Rounding: Per-period depreciation is rounded to cents. The final period is adjusted
+        /// to ensure book value equals salvage exactly (within rounding).
+        let straightLine (cost: int64<Cent>) (salvage: int64<Cent>) (life: int) : DepreciationPeriod array =
+            validateInputs cost salvage life
+
+            let costDec    = Cent.toDecimal cost
+            let salvageDec = Cent.toDecimal salvage
+            let totalDepDec = costDec - salvageDec
+            let rawPerPeriod = totalDepDec / decimal life
+
+            // Recursive builder
+            let rec build p bookValueDec accumulated (acc: DepreciationPeriod list) =
+                if p > life then
+                    acc |> List.rev |> List.toArray
+                else
+                    let isLast = p = life
+                    let depDecCandidate =
+                        if isLast then
+                            bookValueDec - salvageDec
+                        else
+                            rawPerPeriod
+
+                    // Round candidate
+                    let depCentsInitial =
+                        if depDecCandidate <= 0m then 0L<Cent>
+                        else Cent.fromDecimal depDecCandidate
+
+                    // Ensure we don't breach salvage before the last period
+                    let bookValueAfter =
+                        bookValueDec - Cent.toDecimal depCentsInitial
+
+                    let depCents =
+                        if not isLast && bookValueAfter < salvageDec then
+                            // Clamp to exactly reach salvage at this point
+                            let neededDec = bookValueDec - salvageDec
+                            if neededDec <= 0m then 0L<Cent> else Cent.fromDecimal neededDec
+                        else
+                            depCentsInitial
+
+                    let newBookValueDec = bookValueDec - Cent.toDecimal depCents
+                    let newAccumulated = accumulated + depCents
+                    let periodRecord = {
+                        Period       = p
+                        Depreciation = depCents
+                        Accumulated  = newAccumulated
+                        BookValue    = Cent.fromDecimal newBookValueDec
+                        Method       = "SL"
+                    }
+
+                    build (p+1) newBookValueDec newAccumulated (periodRecord :: acc)
+
+            build 1 costDec 0L<Cent> []
+            |> enforceSalvage cost salvage
+
+
+        /// Declining balance depreciation schedule (e.g. rateFactor = 2.0 for 200% / double declining).
+        /// Automatically switches to straight-line when switchToStraightLine = true AND
+        /// the straight-line remainder for the period exceeds the declining balance amount.
+        ///
+        /// cost                : original asset cost (cents)
+        /// salvage             : target final residual book value (cents)
+        /// life                : total number of periods
+        /// rateFactor          : acceleration multiple (1.0 = standard, 2.0 = double, 1.5 = 150%, etc.)
+        /// switchToStraightLine: if true, permanently switches to SL once advantageous
+        ///
+        /// Rounding: Per-period depreciation is rounded to cents; final period adjusted for exact salvage.
+        let decliningBalance
+            (cost: int64<Cent>)
+            (salvage: int64<Cent>)
+            (life: int)
+            (rateFactor: decimal)
+            (switchToStraightLine: bool)
+            : DepreciationPeriod array =
+
+            validateInputs cost salvage life
+            if rateFactor <= 0m then invalidArg (nameof rateFactor) "Rate factor must be > 0."
+
+            let costDec    = Cent.toDecimal cost
+            let salvageDec = Cent.toDecimal salvage
+
+            // Recursive builder
+            let rec build p bookValueDec accumulated inStraight (acc: DepreciationPeriod list) =
+                if p > life then
+                    acc |> List.rev |> List.toArray
+                else
+                    let remaining = life - p + 1
+                    let isLast = p = life
+
+                    let straightLineRemainderDec =
+                        if remaining > 0 then (bookValueDec - salvageDec) / decimal remaining
+                        else 0m
+
+                    let decliningDec =
+                        if isLast then
+                            bookValueDec - salvageDec
+                        else
+                            (rateFactor / decimal life) * bookValueDec
+
+                    // Decide switching
+                    let (chosenDec, inSLNow, tag) =
+                        if inStraight then
+                            (straightLineRemainderDec, true, "DB->SL")
+                        elif switchToStraightLine && straightLineRemainderDec > decliningDec then
+                            (straightLineRemainderDec, true, "DB->SL")
+                        else
+                            (decliningDec, false, "DB")
+
+                    // Prevent going below salvage before last period
+                    let chosenDecClamped =
+                        if not isLast && (bookValueDec - chosenDec) < salvageDec then
+                            bookValueDec - salvageDec
+                        else
+                            chosenDec
+
+                    let depCents =
+                        if chosenDecClamped <= 0m then 0L<Cent>
+                        else Cent.fromDecimal chosenDecClamped
+
+                    let newBookValueDec = bookValueDec - Cent.toDecimal depCents
+                    let newAccumulated = accumulated + depCents
+
+                    let methodFinal =
+                        if inSLNow then "DB->SL" else tag
+
+                    let periodRecord = {
+                        Period       = p
+                        Depreciation = depCents
+                        Accumulated  = newAccumulated
+                        BookValue    = Cent.fromDecimal newBookValueDec
+                        Method       = methodFinal
+                    }
+
+                    build (p+1) newBookValueDec newAccumulated inSLNow (periodRecord :: acc)
+
+            build 1 costDec 0L<Cent> false []
+            |> enforceSalvage cost salvage
+
 
     /// Disclaimer text for educational use
     module Disclaimers =

--- a/src/EquipmentFinance/Depreciation/UK_CapitalAllowances.fs
+++ b/src/EquipmentFinance/Depreciation/UK_CapitalAllowances.fs
@@ -39,8 +39,12 @@ module Types =
         MainPoolRate: decimal
         /// Writing down allowance rate for special rate pool (typically 6%)
         SpecialRatePoolRate: decimal
-        /// Maximum number of years to calculate
+        /// Maximum number of years to calculate. Any pool value left after this many years
+        /// is reported as UnclaimedPool on the schedule rather than silently dropped.
         MaxYears: int
+        /// HMRC small pools allowance threshold: when the pool balance is at or below this
+        /// value, the whole pool may be written off in that year (£1,000 under current rules)
+        SmallPoolThreshold: int64<Cent>
     }
 
     /// Default configuration based on common UK rates
@@ -49,6 +53,7 @@ module Types =
         MainPoolRate = 0.18m
         SpecialRatePoolRate = 0.06m
         MaxYears = 10
+        SmallPoolThreshold = 1_000_00L<Cent>
     }
 
     /// Represents an expenditure item
@@ -75,25 +80,38 @@ module Types =
         PoolValueEndOfYear: int64<Cent>
     }
 
+    /// A capital allowances schedule with any unclaimed residual made explicit
+    type AllowanceSchedule = {
+        /// Year-by-year allowances
+        Years: YearAllowance list
+        /// Pool value remaining unclaimed when the calculation stops at MaxYears.
+        /// Zero when the pool is fully written off within the calculated years.
+        UnclaimedPool: int64<Cent>
+    }
+
 /// UK Capital Allowances calculation functions
 module Calculations =
     
     open Types
 
-    /// Generates a capital allowances schedule for a single expenditure
-    let generateSchedule (config: CapitalAllowanceConfig) (expenditure: Expenditure) : YearAllowance list =
+    /// Generates a capital allowances schedule for a single expenditure.
+    /// Applies the HMRC small pools allowance: when the pool balance is at or below
+    /// config.SmallPoolThreshold, the whole pool is written off in that year.
+    /// Any pool value remaining after MaxYears is reported as UnclaimedPool.
+    let generateSchedule (config: CapitalAllowanceConfig) (expenditure: Expenditure) : AllowanceSchedule =
         if expenditure.Amount <= 0L<Cent> then invalidArg (nameof expenditure.Amount) "Amount must be > 0."
         if config.MaxYears <= 0 then invalidArg (nameof config.MaxYears) "MaxYears must be > 0."
         if config.AnnualInvestmentAllowanceLimit < 0L<Cent> then invalidArg (nameof config.AnnualInvestmentAllowanceLimit) "AnnualInvestmentAllowanceLimit must be >= 0."
         if config.MainPoolRate < 0m then invalidArg (nameof config.MainPoolRate) "MainPoolRate must be >= 0."
         if config.SpecialRatePoolRate < 0m then invalidArg (nameof config.SpecialRatePoolRate) "SpecialRatePoolRate must be >= 0."
-        
+        if config.SmallPoolThreshold < 0L<Cent> then invalidArg (nameof config.SmallPoolThreshold) "SmallPoolThreshold must be >= 0."
+
         let rec calculateYears (year: int) (poolValue: int64<Cent>) (remainingAIA: int64<Cent>) (acc: YearAllowance list) =
             if year > config.MaxYears || poolValue <= 0L<Cent> then
-                List.rev acc
+                { Years = List.rev acc; UnclaimedPool = poolValue }
             else
                 // Calculate AIA for this year (only available in year 1 for single addition)
-                let aiaThisYear = 
+                let aiaThisYear =
                     if year = 1 then
                         min poolValue remainingAIA
                     else
@@ -103,19 +121,20 @@ module Calculations =
                 let valueAfterAIA = poolValue - aiaThisYear
 
                 // Calculate WDA rate based on pool type
-                let wdaRate = 
+                let wdaRate =
                     match expenditure.Pool with
                     | Pool.Main -> config.MainPoolRate
                     | Pool.SpecialRate -> config.SpecialRatePoolRate
 
-                // Calculate Writing Down Allowance (WDA)
-                let rawWda = 
-                    Cent.toDecimalCent valueAfterAIA * wdaRate 
-                    |> Cent.fromDecimalCent (Rounding.RoundWith MidpointRounding.AwayFromZero)
+                // Calculate Writing Down Allowance (WDA), applying the small pools allowance:
+                // a pool at or below the threshold may be written off in full
                 let wda =
-                    if valueAfterAIA > 0L<Cent> && rawWda = 0L<Cent> then
+                    if valueAfterAIA > 0L<Cent> && valueAfterAIA <= config.SmallPoolThreshold then
                         valueAfterAIA
                     else
+                        let rawWda =
+                            Cent.toDecimalCent valueAfterAIA * wdaRate
+                            |> Cent.fromDecimalCent (Rounding.RoundWith MidpointRounding.AwayFromZero)
                         min rawWda valueAfterAIA
 
                 // Total allowances for this year
@@ -137,7 +156,7 @@ module Calculations =
         calculateYears 1 expenditure.Amount config.AnnualInvestmentAllowanceLimit []
 
     /// Generates a schedule using default configuration
-    let scheduleDefault (expenditure: Expenditure) : YearAllowance list =
+    let scheduleDefault (expenditure: Expenditure) : AllowanceSchedule =
         generateSchedule Default expenditure
 
 /// Example configurations and usage

--- a/src/EquipmentFinance/Depreciation/UK_CapitalAllowances.fs
+++ b/src/EquipmentFinance/Depreciation/UK_CapitalAllowances.fs
@@ -1,0 +1,159 @@
+namespace FSharp.Finance.Personal.EquipmentFinance.Depreciation.UK_CapitalAllowances
+
+open System
+open FSharp.Finance.Personal
+open FSharp.Finance.Personal.Calculation
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation
+
+/// UK Capital Allowances module for equipment finance depreciation calculations.
+/// 
+/// IMPORTANT DISCLAIMER: This module is for educational and analytical purposes only.
+/// It is NOT tax advice and should not be used for actual tax calculations without
+/// validation by qualified tax professionals. The implementation includes several
+/// simplifications that may not reflect real-world tax scenarios.
+///
+/// Key simplifications:
+/// - Single asset addition per year only
+/// - No disposals or part-exchanges
+/// - No special rate pool transfers
+/// - Simplified AIA application (full amount in year 1 only)
+/// - No consideration of accounting periods vs tax years
+/// - No integration with other allowances or reliefs
+/// - Rounding uses midpoint-away-from-zero only
+/// - No handling of short periods or cessation
+
+/// UK Capital Allowances types and configuration
+module Types =
+    
+    /// Represents the type of capital allowances pool
+    [<Struct; RequireQualifiedAccess>]
+    type Pool =
+        | Main          // 18% writing down allowance
+        | SpecialRate   // 6% writing down allowance
+
+    /// Configuration for capital allowances calculations
+    type CapitalAllowanceConfig = {
+        /// Annual Investment Allowance limit (£1,000,000 in recent years)
+        AnnualInvestmentAllowanceLimit: decimal
+        /// Writing down allowance rate for main pool (typically 18%)
+        MainPoolRate: decimal
+        /// Writing down allowance rate for special rate pool (typically 6%)
+        SpecialRatePoolRate: decimal
+        /// Maximum number of years to calculate
+        MaxYears: int
+    }
+
+    /// Default configuration based on common UK rates
+    let Default: CapitalAllowanceConfig = {
+        AnnualInvestmentAllowanceLimit = 1_000_000m
+        MainPoolRate = 0.18m
+        SpecialRatePoolRate = 0.06m
+        MaxYears = 10
+    }
+
+    /// Represents an expenditure item
+    type Expenditure = {
+        /// Cost of the asset in pounds
+        Amount: decimal
+        /// Pool classification
+        Pool: Pool
+        /// Description of the asset
+        Description: string
+    }
+
+    /// Represents allowances for a particular year
+    type YearAllowance = {
+        /// Year number (1-based)
+        Year: int
+        /// Annual Investment Allowance claimed
+        AnnualInvestmentAllowance: decimal
+        /// Writing Down Allowance claimed
+        WritingDownAllowance: decimal
+        /// Total allowances for the year
+        TotalAllowances: decimal
+        /// Remaining pool value at year end
+        PoolValueEndOfYear: decimal
+    }
+
+/// UK Capital Allowances calculation functions
+module Calculations =
+    
+    open Types
+
+    /// Rounds a decimal value using midpoint-away-from-zero rounding
+    let roundAwayFromZero (value: decimal) =
+        DepreciationCommon.Rounding.roundCurrency value
+
+    /// Generates a capital allowances schedule for a single expenditure
+    let generateSchedule (config: CapitalAllowanceConfig) (expenditure: Expenditure) : YearAllowance list =
+        
+        let rec calculateYears (year: int) (poolValue: decimal) (remainingAIA: decimal) (acc: YearAllowance list) =
+            if year > config.MaxYears || poolValue <= 0m then
+                List.rev acc
+            else
+                // Calculate AIA for this year (only available in year 1 for single addition)
+                let aiaThisYear = 
+                    if year = 1 then
+                        min poolValue remainingAIA
+                    else
+                        0m
+
+                // Remaining value after AIA
+                let valueAfterAIA = poolValue - aiaThisYear
+
+                // Calculate WDA rate based on pool type
+                let wdaRate = 
+                    match expenditure.Pool with
+                    | Pool.Main -> config.MainPoolRate
+                    | Pool.SpecialRate -> config.SpecialRatePoolRate
+
+                // Calculate WDA
+                let wda = roundAwayFromZero (valueAfterAIA * wdaRate)
+
+                // Total allowances for this year
+                let totalAllowances = aiaThisYear + wda
+
+                // Pool value at end of year
+                let poolValueEOY = valueAfterAIA - wda
+
+                let yearAllowance = {
+                    Year = year
+                    AnnualInvestmentAllowance = roundAwayFromZero aiaThisYear
+                    WritingDownAllowance = roundAwayFromZero wda
+                    TotalAllowances = roundAwayFromZero totalAllowances
+                    PoolValueEndOfYear = roundAwayFromZero poolValueEOY
+                }
+
+                calculateYears (year + 1) poolValueEOY (remainingAIA - aiaThisYear) (yearAllowance :: acc)
+
+        calculateYears 1 expenditure.Amount config.AnnualInvestmentAllowanceLimit []
+
+    /// Generates a schedule using default configuration
+    let scheduleDefault (expenditure: Expenditure) : YearAllowance list =
+        generateSchedule Default expenditure
+
+/// Example configurations and usage
+module Examples =
+    
+    open Types
+    open Calculations
+
+    /// Example: Machinery costing £50,000 in main pool
+    let exampleMachinery = {
+        Amount = 50_000m
+        Pool = Pool.Main
+        Description = "Manufacturing equipment"
+    }
+
+    /// Example: Vehicle costing £30,000 in special rate pool  
+    let exampleVehicle = {
+        Amount = 30_000m
+        Pool = Pool.SpecialRate
+        Description = "Company vehicle"
+    }
+
+    /// Generate example schedule for machinery
+    let exampleMachinerySchedule () = scheduleDefault exampleMachinery
+
+    /// Generate example schedule for vehicle
+    let exampleVehicleSchedule () = scheduleDefault exampleVehicle

--- a/src/EquipmentFinance/Depreciation/UK_CapitalAllowances.fs
+++ b/src/EquipmentFinance/Depreciation/UK_CapitalAllowances.fs
@@ -34,7 +34,7 @@ module Types =
     /// Configuration for capital allowances calculations
     type CapitalAllowanceConfig = {
         /// Annual Investment Allowance limit (£1,000,000 in recent years)
-        AnnualInvestmentAllowanceLimit: decimal
+        AnnualInvestmentAllowanceLimit: int64<Cent>
         /// Writing down allowance rate for main pool (typically 18%)
         MainPoolRate: decimal
         /// Writing down allowance rate for special rate pool (typically 6%)
@@ -45,7 +45,7 @@ module Types =
 
     /// Default configuration based on common UK rates
     let Default: CapitalAllowanceConfig = {
-        AnnualInvestmentAllowanceLimit = 1_000_000m
+        AnnualInvestmentAllowanceLimit = 1_000_000_00L<Cent>
         MainPoolRate = 0.18m
         SpecialRatePoolRate = 0.06m
         MaxYears = 10
@@ -54,7 +54,7 @@ module Types =
     /// Represents an expenditure item
     type Expenditure = {
         /// Cost of the asset in pounds
-        Amount: decimal
+        Amount: int64<Cent>
         /// Pool classification
         Pool: Pool
         /// Description of the asset
@@ -66,13 +66,13 @@ module Types =
         /// Year number (1-based)
         Year: int
         /// Annual Investment Allowance claimed
-        AnnualInvestmentAllowance: decimal
+        AnnualInvestmentAllowance: int64<Cent>
         /// Writing Down Allowance claimed
-        WritingDownAllowance: decimal
+        WritingDownAllowance: int64<Cent>
         /// Total allowances for the year
-        TotalAllowances: decimal
+        TotalAllowances: int64<Cent>
         /// Remaining pool value at year end
-        PoolValueEndOfYear: decimal
+        PoolValueEndOfYear: int64<Cent>
     }
 
 /// UK Capital Allowances calculation functions
@@ -80,15 +80,11 @@ module Calculations =
     
     open Types
 
-    /// Rounds a decimal value using midpoint-away-from-zero rounding
-    let roundAwayFromZero (value: decimal) =
-        DepreciationCommon.Rounding.roundCurrency value
-
     /// Generates a capital allowances schedule for a single expenditure
     let generateSchedule (config: CapitalAllowanceConfig) (expenditure: Expenditure) : YearAllowance list =
         
-        let rec calculateYears (year: int) (poolValue: decimal) (remainingAIA: decimal) (acc: YearAllowance list) =
-            if year > config.MaxYears || poolValue <= 0m then
+        let rec calculateYears (year: int) (poolValue: int64<Cent>) (remainingAIA: int64<Cent>) (acc: YearAllowance list) =
+            if year > config.MaxYears || poolValue <= 0L<Cent> then
                 List.rev acc
             else
                 // Calculate AIA for this year (only available in year 1 for single addition)
@@ -96,7 +92,7 @@ module Calculations =
                     if year = 1 then
                         min poolValue remainingAIA
                     else
-                        0m
+                        0L<Cent>
 
                 // Remaining value after AIA
                 let valueAfterAIA = poolValue - aiaThisYear
@@ -107,8 +103,10 @@ module Calculations =
                     | Pool.Main -> config.MainPoolRate
                     | Pool.SpecialRate -> config.SpecialRatePoolRate
 
-                // Calculate WDA
-                let wda = roundAwayFromZero (valueAfterAIA * wdaRate)
+                // Calculate Writing Down Allowance (WDA)
+                let wda = 
+                    Cent.toDecimalCent valueAfterAIA * wdaRate 
+                    |> Cent.fromDecimalCent (Rounding.RoundWith MidpointRounding.AwayFromZero)
 
                 // Total allowances for this year
                 let totalAllowances = aiaThisYear + wda
@@ -118,10 +116,10 @@ module Calculations =
 
                 let yearAllowance = {
                     Year = year
-                    AnnualInvestmentAllowance = roundAwayFromZero aiaThisYear
-                    WritingDownAllowance = roundAwayFromZero wda
-                    TotalAllowances = roundAwayFromZero totalAllowances
-                    PoolValueEndOfYear = roundAwayFromZero poolValueEOY
+                    AnnualInvestmentAllowance = aiaThisYear
+                    WritingDownAllowance = wda
+                    TotalAllowances = totalAllowances
+                    PoolValueEndOfYear = poolValueEOY
                 }
 
                 calculateYears (year + 1) poolValueEOY (remainingAIA - aiaThisYear) (yearAllowance :: acc)
@@ -140,14 +138,14 @@ module Examples =
 
     /// Example: Machinery costing £50,000 in main pool
     let exampleMachinery = {
-        Amount = 50_000m
+        Amount = 50_000_00L<Cent>
         Pool = Pool.Main
         Description = "Manufacturing equipment"
     }
 
     /// Example: Vehicle costing £30,000 in special rate pool  
     let exampleVehicle = {
-        Amount = 30_000m
+        Amount = 30_000_00L<Cent>
         Pool = Pool.SpecialRate
         Description = "Company vehicle"
     }

--- a/src/EquipmentFinance/Depreciation/UK_CapitalAllowances.fs
+++ b/src/EquipmentFinance/Depreciation/UK_CapitalAllowances.fs
@@ -82,6 +82,11 @@ module Calculations =
 
     /// Generates a capital allowances schedule for a single expenditure
     let generateSchedule (config: CapitalAllowanceConfig) (expenditure: Expenditure) : YearAllowance list =
+        if expenditure.Amount <= 0L<Cent> then invalidArg (nameof expenditure.Amount) "Amount must be > 0."
+        if config.MaxYears <= 0 then invalidArg (nameof config.MaxYears) "MaxYears must be > 0."
+        if config.AnnualInvestmentAllowanceLimit < 0L<Cent> then invalidArg (nameof config.AnnualInvestmentAllowanceLimit) "AnnualInvestmentAllowanceLimit must be >= 0."
+        if config.MainPoolRate < 0m then invalidArg (nameof config.MainPoolRate) "MainPoolRate must be >= 0."
+        if config.SpecialRatePoolRate < 0m then invalidArg (nameof config.SpecialRatePoolRate) "SpecialRatePoolRate must be >= 0."
         
         let rec calculateYears (year: int) (poolValue: int64<Cent>) (remainingAIA: int64<Cent>) (acc: YearAllowance list) =
             if year > config.MaxYears || poolValue <= 0L<Cent> then
@@ -104,9 +109,14 @@ module Calculations =
                     | Pool.SpecialRate -> config.SpecialRatePoolRate
 
                 // Calculate Writing Down Allowance (WDA)
-                let wda = 
+                let rawWda = 
                     Cent.toDecimalCent valueAfterAIA * wdaRate 
                     |> Cent.fromDecimalCent (Rounding.RoundWith MidpointRounding.AwayFromZero)
+                let wda =
+                    if valueAfterAIA > 0L<Cent> && rawWda = 0L<Cent> then
+                        valueAfterAIA
+                    else
+                        min rawWda valueAfterAIA
 
                 // Total allowances for this year
                 let totalAllowances = aiaThisYear + wda

--- a/src/EquipmentFinance/Depreciation/US_MACRS.fs
+++ b/src/EquipmentFinance/Depreciation/US_MACRS.fs
@@ -186,7 +186,7 @@ module Calculations =
         let desc = assetDescription.ToLowerInvariant()
         if desc.Contains("computer") || desc.Contains("car") || desc.Contains("truck") then
             AssetClass.FiveYear
-        elif desc.Contains("furniture") || desc.Contains("equipment") then
+        elif desc.Contains("furniture") || desc.Contains("manufacturing") then
             AssetClass.SevenYear
         elif desc.Contains("building") then
             AssetClass.FifteenYear
@@ -201,7 +201,7 @@ module Examples =
 
     /// Example: Computer equipment costing $10,000 (5-year property)
     let exampleComputer = {
-        CostBasis = 10000L<Cent>
+        CostBasis = 10000_00L<Cent>
         PlacedInServiceDate = DateDay.Date(2024, 1, 1)
         PropertyClass = AssetClass.FiveYear
         Convention = Convention.HalfYear
@@ -209,7 +209,7 @@ module Examples =
 
     /// Example: Office furniture costing $5,000 (7-year property)
     let exampleFurniture = {
-        CostBasis = 5000L<Cent>
+        CostBasis = 5000_00L<Cent>
         PlacedInServiceDate = DateDay.Date(2024, 1, 1)
         PropertyClass = AssetClass.SevenYear
         Convention = Convention.HalfYear
@@ -217,7 +217,7 @@ module Examples =
 
     /// Example: Manufacturing equipment costing $25,000 (7-year property)
     let exampleEquipment = {
-        CostBasis = 25000L<Cent>
+        CostBasis = 25000_00L<Cent>
         PlacedInServiceDate = DateDay.Date(2024, 1, 1)
         PropertyClass = AssetClass.SevenYear
         Convention = Convention.HalfYear

--- a/src/EquipmentFinance/Depreciation/US_MACRS.fs
+++ b/src/EquipmentFinance/Depreciation/US_MACRS.fs
@@ -86,8 +86,8 @@ module Tables =
         [| 10.00m; 18.00m; 14.40m; 11.52m; 9.22m; 7.37m; 6.55m; 6.55m; 6.56m; 6.55m; 3.28m |]
         // 15-year
         [| 5.00m; 9.50m; 8.55m; 7.70m; 6.93m; 6.23m; 5.90m; 5.90m; 5.91m; 5.90m; 5.91m; 5.90m; 5.91m; 5.90m; 5.91m; 2.95m |]
-        // 20-year
-        [| 3.75m; 7.22m; 6.68m; 6.18m; 5.71m; 5.29m; 4.89m; 4.52m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 2.25m |]
+        // 20-year (IRS Table A-1, three-decimal percentages summing to exactly 100.000)
+        [| 3.750m; 7.219m; 6.677m; 6.177m; 5.713m; 5.285m; 4.888m; 4.522m; 4.462m; 4.461m; 4.462m; 4.461m; 4.462m; 4.461m; 4.462m; 4.461m; 4.462m; 4.461m; 4.462m; 4.461m; 2.231m |]
     |]
 
     /// Get the depreciation percentages for a given asset class
@@ -186,17 +186,34 @@ module Calculations =
                 BookValue = 0L<Cent>
             }
 
-    /// Determine the MACRS property class based on asset description
-    let classifyAsset (assetDescription: string) : AssetClass =
+    /// Attempt to determine the MACRS property class from an asset description.
+    /// Returns None when no keyword matches, so callers can surface the fact that an
+    /// asset class was assumed rather than recognized.
+    /// Real-property descriptions (buildings etc.) are rejected: under MACRS, buildings are
+    /// 27.5-year (residential) / 39-year (nonresidential) straight-line REAL property, which
+    /// this simplified module does not model.
+    let tryClassifyAsset (assetDescription: string) : AssetClass option =
         let desc = assetDescription.ToLowerInvariant()
-        if desc.Contains("computer") || desc.Contains("car") || desc.Contains("truck") then
-            AssetClass.FiveYear
-        elif desc.Contains("furniture") || desc.Contains("manufacturing") then
-            AssetClass.SevenYear
-        elif desc.Contains("building") then
-            AssetClass.FifteenYear
+        let realPropertyKeywords = [ "building"; "warehouse"; "real property"; "real estate"; "residential"; "nonresidential"; "apartment"; "office block" ]
+        if realPropertyKeywords |> List.exists desc.Contains then
+            invalidArg (nameof assetDescription)
+                "Real property (27.5-year residential / 39-year nonresidential straight-line) is not supported by this simplified MACRS module."
+        elif desc.Contains "computer" || desc.Contains "car" || desc.Contains "truck" || desc.Contains "vehicle" then
+            Some AssetClass.FiveYear
+        elif desc.Contains "furniture" || desc.Contains "manufacturing" then
+            Some AssetClass.SevenYear
+        elif desc.Contains "boat" || desc.Contains "barge" then
+            Some AssetClass.TenYear
+        elif desc.Contains "land improvement" || desc.Contains "parking lot" || desc.Contains "fence" || desc.Contains "landscaping" || desc.Contains "gas station" || desc.Contains "billboard" then
+            Some AssetClass.FifteenYear
         else
-            AssetClass.FiveYear // default to 5-year for most business equipment
+            None
+
+    /// Determine the MACRS property class based on asset description, defaulting to
+    /// FiveYear (most business equipment) when no keyword matches.
+    /// Use tryClassifyAsset to detect whether the default assumption was applied.
+    let classifyAsset (assetDescription: string) : AssetClass =
+        tryClassifyAsset assetDescription |> Option.defaultValue AssetClass.FiveYear
 
 /// Example configurations and usage
 module Examples =

--- a/src/EquipmentFinance/Depreciation/US_MACRS.fs
+++ b/src/EquipmentFinance/Depreciation/US_MACRS.fs
@@ -1,0 +1,233 @@
+namespace FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
+
+open System
+open FSharp.Finance.Personal
+open FSharp.Finance.Personal.Calculation
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation
+
+/// US MACRS (Modified Accelerated Cost Recovery System) module for equipment depreciation calculations.
+/// 
+/// IMPORTANT DISCLAIMER: This module is for educational and analytical purposes only.
+/// It is NOT tax advice and should not be used for actual tax calculations without
+/// validation by qualified tax professionals. The implementation includes several
+/// simplifications that may not reflect real-world tax scenarios.
+///
+/// Key simplifications:
+/// - Limited to half-year convention only
+/// - Simplified asset class definitions
+/// - No mid-quarter convention handling
+/// - No Section 179 deduction integration
+/// - No bonus depreciation considerations
+/// - No averaging conventions for real property
+/// - Simplified recovery period options
+/// - No consideration of placed-in-service dates
+/// - Educational percentage tables only
+
+/// MACRS asset classes and configuration types
+module Types =
+    
+    /// Represents MACRS asset classes with their typical recovery periods
+    [<Struct; RequireQualifiedAccess>]
+    type AssetClass =
+        | ThreeYear     // Certain special tools, small manufacturing equipment
+        | FiveYear      // Most equipment, computers, office machinery, vehicles
+        | SevenYear     // Office furniture, equipment not in other classes
+        | TenYear       // Boats, barges, single-purpose structures
+        | FifteenYear   // Land improvements, gas stations, billboards
+        | TwentyYear    // Farm buildings, utility property
+
+    /// MACRS depreciation convention
+    [<Struct; RequireQualifiedAccess>]
+    type Convention =
+        | HalfYear      // half-year convention (most common)
+        | MidQuarter    // mid-quarter convention (when over 40% of assets placed in service in Q4)
+
+    /// Represents a year in the depreciation schedule
+    type DepreciationYear = {
+        /// Year number (1-based)
+        Year: int
+        /// Depreciation percentage for this year
+        DepreciationRate: decimal
+        /// Annual depreciation amount
+        DepreciationAmount: int64<Cent>
+        /// Accumulated depreciation to date
+        AccumulatedDepreciation: int64<Cent>
+        /// Remaining book value
+        BookValue: int64<Cent>
+    }
+
+    /// Configuration for MACRS calculations
+    type MacrsAsset = {
+        /// Original cost/basis of the asset
+        CostBasis: int64<Cent>
+        /// Date the asset was placed in service
+        PlacedInServiceDate: DateDay.Date
+        /// Asset classification
+        PropertyClass: AssetClass
+        /// Convention used
+        Convention: Convention
+    }
+
+/// MACRS percentage tables and lookups
+module Tables =
+    
+    open Types
+
+    /// Half-year convention depreciation percentages by asset class and year
+    /// These are simplified educational tables - actual IRS tables should be used for real calculations
+    let private halfYearPercentages = [|
+        // 3-year
+        [| 33.33m; 44.45m; 14.81m; 7.41m |]
+        // 5-year  
+        [| 20.00m; 32.00m; 19.20m; 11.52m; 11.52m; 5.76m |]
+        // 7-year
+        [| 14.29m; 24.49m; 17.49m; 12.49m; 8.93m; 8.92m; 8.93m; 4.46m |]
+        // 10-year
+        [| 10.00m; 18.00m; 14.40m; 11.52m; 9.22m; 7.37m; 6.55m; 6.55m; 6.56m; 6.55m; 3.28m |]
+        // 15-year
+        [| 5.00m; 9.50m; 8.55m; 7.70m; 6.93m; 6.23m; 5.90m; 5.90m; 5.91m; 5.90m; 5.91m; 5.90m; 5.91m; 5.90m; 5.91m; 2.95m |]
+        // 20-year
+        [| 3.75m; 7.22m; 6.68m; 6.18m; 5.71m; 5.29m; 4.89m; 4.52m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 4.46m; 2.25m |]
+    |]
+
+    /// Get the depreciation percentages for a given asset class
+    let getDepreciationPercentages (assetClass: AssetClass) : decimal array =
+        let tableIndex = 
+            match assetClass with
+            | AssetClass.ThreeYear -> 0
+            | AssetClass.FiveYear -> 1
+            | AssetClass.SevenYear -> 2
+            | AssetClass.TenYear -> 3
+            | AssetClass.FifteenYear -> 4
+            | AssetClass.TwentyYear -> 5
+        
+        halfYearPercentages.[tableIndex]
+
+    /// Get the MACRS percentage for a given property class and year
+    let getMacrsPercentage (propertyClass: AssetClass) (year: int) : decimal =
+        let percentages = getDepreciationPercentages propertyClass
+        if year > 0 && year <= percentages.Length then
+            percentages.[year - 1]
+        else
+            0m
+
+/// MACRS calculation functions
+module Calculations =
+    
+    open Types
+    open Tables
+
+    /// Calculate the MACRS depreciation schedule for an asset
+    let generateSchedule (asset: MacrsAsset) : DepreciationYear list =
+        let percentages = getDepreciationPercentages asset.PropertyClass
+        
+        let rec calculateYears (year: int) (accumulatedDep: int64<Cent>) (acc: DepreciationYear list) =
+            if year > percentages.Length then
+                List.rev acc
+            else
+                let rate = percentages.[year - 1] / 100m // Convert percentage to decimal
+                let depreciationAmount = 
+                    decimal asset.CostBasis * rate * 1m<Cent>
+                    |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+                let newAccumulated = accumulatedDep + depreciationAmount
+                let bookValue = asset.CostBasis - newAccumulated
+
+                let depreciationYear = {
+                    Year = year
+                    DepreciationRate = rate
+                    DepreciationAmount = depreciationAmount
+                    AccumulatedDepreciation = newAccumulated
+                    BookValue = bookValue
+                }
+
+                calculateYears (year + 1) newAccumulated (depreciationYear :: acc)
+
+        calculateYears 1 0L<Cent> []
+
+    /// Get the recovery period for an asset class
+    let getRecoveryPeriod (assetClass: AssetClass) : int =
+        match assetClass with
+        | AssetClass.ThreeYear -> 3
+        | AssetClass.FiveYear -> 5
+        | AssetClass.SevenYear -> 7
+        | AssetClass.TenYear -> 10
+        | AssetClass.FifteenYear -> 15
+        | AssetClass.TwentyYear -> 20
+
+    /// Calculate MACRS depreciation for a specific year
+    let calculateMacrsDepreciation (asset: MacrsAsset) (year: int) : DepreciationYear =
+        let percentage = getMacrsPercentage asset.PropertyClass year
+        let depreciationAmount = 
+            decimal asset.CostBasis * (percentage / 100m) * 1m<Cent>
+            |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+        
+        // Calculate cumulative depreciation through this year
+        let cumulativeDepreciation = 
+            [1..year]
+            |> List.sumBy (fun y -> 
+                let pct = getMacrsPercentage asset.PropertyClass y
+                decimal asset.CostBasis * (pct / 100m))
+            |> (*) 1m<Cent>
+            |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+            |> min asset.CostBasis
+        
+        let bookValue = asset.CostBasis - cumulativeDepreciation
+        
+        {
+            Year = year
+            DepreciationRate = percentage / 100m
+            DepreciationAmount = depreciationAmount
+            AccumulatedDepreciation = cumulativeDepreciation
+            BookValue = bookValue
+        }
+
+    /// Determine the MACRS property class based on asset description
+    let classifyAsset (assetDescription: string) : AssetClass =
+        let desc = assetDescription.ToLowerInvariant()
+        if desc.Contains("computer") || desc.Contains("car") || desc.Contains("truck") then
+            AssetClass.FiveYear
+        elif desc.Contains("furniture") || desc.Contains("equipment") then
+            AssetClass.SevenYear
+        elif desc.Contains("building") then
+            AssetClass.FifteenYear
+        else
+            AssetClass.FiveYear // default to 5-year for most business equipment
+
+/// Example configurations and usage
+module Examples =
+    
+    open Types
+    open Calculations
+
+    /// Example: Computer equipment costing $10,000 (5-year property)
+    let exampleComputer = {
+        CostBasis = 10000L<Cent>
+        PlacedInServiceDate = DateDay.Date(2024, 1, 1)
+        PropertyClass = AssetClass.FiveYear
+        Convention = Convention.HalfYear
+    }
+
+    /// Example: Office furniture costing $5,000 (7-year property)
+    let exampleFurniture = {
+        CostBasis = 5000L<Cent>
+        PlacedInServiceDate = DateDay.Date(2024, 1, 1)
+        PropertyClass = AssetClass.SevenYear
+        Convention = Convention.HalfYear
+    }
+
+    /// Example: Manufacturing equipment costing $25,000 (7-year property)
+    let exampleEquipment = {
+        CostBasis = 25000L<Cent>
+        PlacedInServiceDate = DateDay.Date(2024, 1, 1)
+        PropertyClass = AssetClass.SevenYear
+        Convention = Convention.HalfYear
+    }
+
+    /// Generate example schedule for computer
+    let exampleComputerSchedule () = generateSchedule exampleComputer
+
+    /// Generate example schedule for furniture
+    let exampleFurnitureSchedule () = generateSchedule exampleFurniture
+
+    /// Generate example schedule for equipment
+    let exampleEquipmentSchedule () = generateSchedule exampleEquipment

--- a/src/EquipmentFinance/Depreciation/US_MACRS.fs
+++ b/src/EquipmentFinance/Depreciation/US_MACRS.fs
@@ -119,6 +119,10 @@ module Calculations =
 
     /// Calculate the MACRS depreciation schedule for an asset
     let generateSchedule (asset: MacrsAsset) : DepreciationYear list =
+        if asset.CostBasis <= 0L<Cent> then invalidArg (nameof asset.CostBasis) "CostBasis must be > 0."
+        if asset.Convention <> Convention.HalfYear then
+            invalidArg (nameof asset.Convention) "Only HalfYear convention is currently supported."
+
         let percentages = getDepreciationPercentages asset.PropertyClass
         
         let rec calculateYears (year: int) (accumulatedDep: int64<Cent>) (acc: DepreciationYear list) =
@@ -126,9 +130,11 @@ module Calculations =
                 List.rev acc
             else
                 let rate = percentages.[year - 1] / 100m // Convert percentage to decimal
-                let depreciationAmount = 
+                let rawDepreciationAmount = 
                     decimal asset.CostBasis * rate * 1m<Cent>
                     |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+                let remainingBasis = asset.CostBasis - accumulatedDep
+                let depreciationAmount = min rawDepreciationAmount remainingBasis
                 let newAccumulated = accumulatedDep + depreciationAmount
                 let bookValue = asset.CostBasis - newAccumulated
 
@@ -156,30 +162,29 @@ module Calculations =
 
     /// Calculate MACRS depreciation for a specific year
     let calculateMacrsDepreciation (asset: MacrsAsset) (year: int) : DepreciationYear =
+        if asset.Convention <> Convention.HalfYear then
+            invalidArg (nameof asset.Convention) "Only HalfYear convention is currently supported."
+        if year <= 0 then invalidArg (nameof year) "Year must be > 0."
+
         let percentage = getMacrsPercentage asset.PropertyClass year
+        let schedule = generateSchedule asset
+        let matchedYear = schedule |> List.tryFind (fun depreciationYear -> depreciationYear.Year = year)
+
         let depreciationAmount = 
             decimal asset.CostBasis * (percentage / 100m) * 1m<Cent>
             |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
         
         // Calculate cumulative depreciation through this year
-        let cumulativeDepreciation = 
-            [1..year]
-            |> List.sumBy (fun y -> 
-                let pct = getMacrsPercentage asset.PropertyClass y
-                decimal asset.CostBasis * (pct / 100m))
-            |> (*) 1m<Cent>
-            |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
-            |> min asset.CostBasis
-        
-        let bookValue = asset.CostBasis - cumulativeDepreciation
-        
-        {
-            Year = year
-            DepreciationRate = percentage / 100m
-            DepreciationAmount = depreciationAmount
-            AccumulatedDepreciation = cumulativeDepreciation
-            BookValue = bookValue
-        }
+        match matchedYear with
+        | Some depreciationYear -> depreciationYear
+        | None ->
+            {
+                Year = year
+                DepreciationRate = percentage / 100m
+                DepreciationAmount = depreciationAmount
+                AccumulatedDepreciation = asset.CostBasis
+                BookValue = 0L<Cent>
+            }
 
     /// Determine the MACRS property class based on asset description
     let classifyAsset (assetDescription: string) : AssetClass =

--- a/src/EquipmentFinance/Lease.fs
+++ b/src/EquipmentFinance/Lease.fs
@@ -89,26 +89,49 @@ module Lease =
         RemainingLiability: int64<Cent>
     }
 
-    /// Calculate lease payment for given terms
+    /// Calculate level lease payment with optional residual (balloon)
+    /// Assumptions:
+    /// - All incoming monetary values are int64<Cent>
+    /// - UpfrontPayment reduces financed amount
+    /// - ResidualValue discounted over total periods
+    /// - Interest.Rate.Annual is nominal annual; divided by payments/year
     let calculateLeasePayment (terms: EquipmentLeaseTerms) : int64<Cent> =
         let periodsPerYear = terms.PaymentFrequency.PaymentsPerYear
         let totalPeriods = terms.TermMonths * periodsPerYear / 12
-        let periodRate = 
+        if totalPeriods <= 0 then invalidArg (nameof terms.TermMonths) "Computed total periods <= 0."
+
+        let periodRate =
             match terms.ImplicitRate with
             | Interest.Rate.Zero -> 0m
-            | Interest.Rate.Annual (Percent rate) -> rate / 100m / decimal periodsPerYear
-            | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / decimal periodsPerYear
-        
+            | Interest.Rate.Annual (Calculation.Percent p) ->
+                p / 100m / decimal periodsPerYear
+            | Interest.Rate.Daily (Calculation.Percent p) ->
+                // Interpret as nominal daily simple rate -> nominal annual -> per-period
+                (p / 100m) * 365m / decimal periodsPerYear
+
+        let fairValue = Cent.toDecimal terms.FairMarketValue
+        let upfront   = Cent.toDecimal terms.UpfrontPayment
+        let residual  = Cent.toDecimal terms.ResidualValue
+
+        let financedPrincipal = fairValue - upfront
+        if financedPrincipal <= 0m then invalidArg "terms.UpfrontPayment" "Upfront payment >= fair value."
+        if residual >= fairValue then invalidArg "terms.ResidualValue" "Residual must be < fair value."
+
         if periodRate = 0m then
-            // No interest, simple division
-            (terms.FairMarketValue - terms.ResidualValue) / int64 totalPeriods
+            // Zero-rate linear repayment less residual
+            let paymentDec = (financedPrincipal - residual) / decimal totalPeriods
+            if paymentDec <= 0m then invalidOp "Non-positive payment under zero-rate scenario."
+            Cent.fromDecimal paymentDec
         else
-            let leasableAmount = terms.FairMarketValue - terms.UpfrontPayment
-            let pvOfResidual = decimal terms.ResidualValue / pow (1m + periodRate) (decimal totalPeriods)
-            let amountToFinance = decimal leasableAmount - pvOfResidual
-            
-            let payment = amountToFinance * periodRate / (1m - pow (1m + periodRate) (decimal -totalPeriods))
-            payment * 1m<Cent> |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+            let growth = pow (1m + periodRate) (decimal totalPeriods)
+            let pvResidual = residual / growth
+            let baseAmount = financedPrincipal - pvResidual
+            if baseAmount <= 0m then invalidOp "Discounted residual >= financed principal."
+            let denom = 1m - 1m / growth
+            if denom = 0m then invalidOp "Denominator collapsed (rate too small / overflow)."
+            let paymentDec = baseAmount * periodRate / denom
+            if paymentDec <= 0m then invalidOp "Computed payment is non-positive."
+            Cent.fromDecimal paymentDec
 
     /// Calculate lease payment details
     let calculateLeaseDetails (terms: EquipmentLeaseTerms) : LeaseCalculation =

--- a/src/EquipmentFinance/Lease.fs
+++ b/src/EquipmentFinance/Lease.fs
@@ -1,0 +1,251 @@
+namespace FSharp.Finance.Personal.EquipmentFinance
+
+open System
+open FSharp.Finance.Personal
+open FSharp.Finance.Personal.Calculation
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
+
+/// Equipment lease calculations and analysis for equipment finance
+module Lease =
+
+    /// Simple power function for financial calculations
+    let private pow (base': decimal) (power: decimal) = 
+        decimal (Math.Pow(double base', double power))
+
+    /// Type of lease for equipment financing
+    [<Struct; RequireQualifiedAccess>]
+    type LeaseType =
+        | OperatingLease    // Off-balance-sheet, lessor retains ownership
+        | FinanceLease      // On-balance-sheet, lessee assumes ownership risks
+        | CapitalLease      // Similar to finance lease under older accounting standards
+
+    /// Lease payment frequency
+    [<Struct; RequireQualifiedAccess>]
+    type PaymentFrequency =
+        | Monthly           // Monthly payments
+        | Quarterly         // Quarterly payments
+        | SemiAnnual        // Semi-annual payments
+        | Annual            // Annual payments
+
+        /// Convert frequency to number of payments per year
+        member pf.PaymentsPerYear =
+            match pf with
+            | Monthly -> 12
+            | Quarterly -> 4
+            | SemiAnnual -> 2
+            | Annual -> 1
+
+    /// Terms and conditions for an equipment lease
+    type EquipmentLeaseTerms = {
+        /// The equipment being leased
+        EquipmentDescription: string
+        /// The fair market value of the equipment
+        FairMarketValue: int64<Cent>
+        /// The lease term in months
+        TermMonths: int
+        /// The type of lease
+        LeaseType: LeaseType
+        /// Payment frequency
+        PaymentFrequency: PaymentFrequency
+        /// Lease payment amount
+        LeasePayment: int64<Cent>
+        /// Any upfront payment or security deposit
+        UpfrontPayment: int64<Cent>
+        /// Residual value at end of lease term
+        ResidualValue: int64<Cent>
+        /// Purchase option at lease end
+        PurchaseOption: int64<Cent> option
+        /// Implicit interest rate in the lease
+        ImplicitRate: Interest.Rate
+    }
+
+    /// Lease payment calculation result
+    type LeaseCalculation = {
+        /// The periodic lease payment
+        LeasePayment: int64<Cent>
+        /// Total payments over the lease term
+        TotalPayments: int64<Cent>
+        /// Total cost of leasing vs buying
+        TotalCost: int64<Cent>
+        /// The annual percentage rate equivalent
+        AprEquivalent: Percent
+        /// Present value of lease payments
+        PresentValue: int64<Cent>
+    }
+
+    /// Lease schedule item
+    type LeaseScheduleItem = {
+        /// Payment number (1-based)
+        PaymentNumber: int
+        /// Payment due date
+        PaymentDate: DateDay.Date
+        /// The lease payment amount
+        PaymentAmount: int64<Cent>
+        /// Principal portion (for finance leases)
+        PrincipalPortion: int64<Cent>
+        /// Interest portion (for finance leases)
+        InterestPortion: int64<Cent>
+        /// Remaining lease liability (for finance leases)
+        RemainingLiability: int64<Cent>
+    }
+
+    /// Calculate lease payment for given terms
+    let calculateLeasePayment (terms: EquipmentLeaseTerms) : int64<Cent> =
+        let periodsPerYear = terms.PaymentFrequency.PaymentsPerYear
+        let totalPeriods = terms.TermMonths * periodsPerYear / 12
+        let periodRate = 
+            match terms.ImplicitRate with
+            | Interest.Rate.Zero -> 0m
+            | Interest.Rate.Annual (Percent rate) -> rate / 100m / decimal periodsPerYear
+            | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / decimal periodsPerYear
+        
+        if periodRate = 0m then
+            // No interest, simple division
+            (terms.FairMarketValue - terms.ResidualValue) / int64 totalPeriods
+        else
+            let leasableAmount = terms.FairMarketValue - terms.UpfrontPayment
+            let pvOfResidual = decimal terms.ResidualValue / pow (1m + periodRate) (decimal totalPeriods)
+            let amountToFinance = decimal leasableAmount - pvOfResidual
+            
+            let payment = amountToFinance * periodRate / (1m - pow (1m + periodRate) (decimal -totalPeriods))
+            payment * 1m<Cent> |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+
+    /// Calculate lease payment details
+    let calculateLeaseDetails (terms: EquipmentLeaseTerms) : LeaseCalculation =
+        let leasePayment = 
+            if terms.LeasePayment > 0L<Cent> then terms.LeasePayment 
+            else calculateLeasePayment terms
+        
+        let periodsPerYear = terms.PaymentFrequency.PaymentsPerYear
+        let totalPeriods = terms.TermMonths * periodsPerYear / 12
+        let totalPayments = leasePayment * int64 totalPeriods + terms.UpfrontPayment
+        
+        let totalCost = 
+            match terms.PurchaseOption with
+            | Some purchasePrice -> totalPayments + purchasePrice
+            | None -> totalPayments
+        
+        // Calculate present value of lease payments
+        let periodRate = 
+            match terms.ImplicitRate with
+            | Interest.Rate.Zero -> 0m
+            | Interest.Rate.Annual (Percent rate) -> rate / 100m / decimal periodsPerYear
+            | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / decimal periodsPerYear
+        
+        let presentValue = 
+            if periodRate = 0m then
+                totalPayments
+            else
+                let pv = [1..totalPeriods]
+                         |> List.sumBy (fun period -> decimal leasePayment / pow (1m + periodRate) (decimal period))
+                         |> (+) (decimal terms.UpfrontPayment)
+                         |> (*) 1m<Cent>
+                Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero) pv
+        
+        let aprEquivalent = 
+            match terms.ImplicitRate with
+            | Interest.Rate.Zero -> Percent 0m
+            | Interest.Rate.Annual percent -> percent
+            | Interest.Rate.Daily (Percent rate) -> Percent (rate * 365m)
+        
+        {
+            LeasePayment = leasePayment
+            TotalPayments = totalPayments
+            TotalCost = totalCost
+            AprEquivalent = aprEquivalent
+            PresentValue = presentValue
+        }
+
+    /// Generate lease payment schedule
+    let generateLeaseSchedule (terms: EquipmentLeaseTerms) (startDate: DateDay.Date) : LeaseScheduleItem array =
+        let leasePayment = 
+            if terms.LeasePayment > 0L<Cent> then terms.LeasePayment 
+            else calculateLeasePayment terms
+        
+        let periodsPerYear = terms.PaymentFrequency.PaymentsPerYear
+        let totalPeriods = terms.TermMonths * periodsPerYear / 12
+        let periodRate = 
+            match terms.ImplicitRate with
+            | Interest.Rate.Zero -> 0m
+            | Interest.Rate.Annual (Percent rate) -> rate / 100m / decimal periodsPerYear
+            | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / decimal periodsPerYear
+        
+        let monthsPerPeriod = 12 / periodsPerYear
+        
+        let rec generateSchedule paymentNum currentDate liability acc =
+            if paymentNum > totalPeriods then
+                acc |> List.rev |> Array.ofList
+            else
+                let interestPortion = 
+                    if terms.LeaseType = LeaseType.OperatingLease then
+                        0L<Cent> // Operating leases don't split principal/interest
+                    else
+                        decimal liability * periodRate * 1m<Cent>
+                        |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+                
+                let principalPortion = 
+                    if terms.LeaseType = LeaseType.OperatingLease then
+                        0L<Cent> // Operating leases don't split principal/interest
+                    else
+                        leasePayment - interestPortion
+                
+                let newLiability = 
+                    if terms.LeaseType = LeaseType.OperatingLease then
+                        liability // No liability reduction for operating leases
+                    else
+                        liability - principalPortion
+                
+                let paymentDate = startDate.AddMonths(paymentNum * monthsPerPeriod)
+                
+                let item = {
+                    PaymentNumber = paymentNum
+                    PaymentDate = paymentDate
+                    PaymentAmount = leasePayment
+                    PrincipalPortion = principalPortion
+                    InterestPortion = interestPortion
+                    RemainingLiability = newLiability
+                }
+                
+                generateSchedule (paymentNum + 1) paymentDate newLiability (item :: acc)
+        
+        let initialLiability = 
+            if terms.LeaseType = LeaseType.OperatingLease then
+                terms.FairMarketValue // For display purposes
+            else
+                terms.FairMarketValue - terms.UpfrontPayment
+        
+        generateSchedule 1 startDate initialLiability []
+
+    /// Analyze lease vs buy decision
+    type LeaseVsBuyAnalysis = {
+        /// Lease calculation details
+        LeaseDetails: LeaseCalculation
+        /// Depreciation schedule if equipment were purchased
+        PurchaseDepreciation: Types.DepreciationYear list
+        /// Lease payment schedule
+        LeaseSchedule: LeaseScheduleItem array
+        /// Net advantage to leasing (positive means leasing is better)
+        NetAdvantageToLeasing: int64<Cent> option
+    }
+
+    /// Perform lease vs buy analysis
+    let analyzeLeaseVsBuy (terms: EquipmentLeaseTerms) (startDate: DateDay.Date) : LeaseVsBuyAnalysis =
+        let leaseDetails = calculateLeaseDetails terms
+        let leaseSchedule = generateLeaseSchedule terms startDate
+        
+        // Create depreciation schedule for purchase scenario
+        let macrsAsset = {
+            Types.CostBasis = terms.FairMarketValue
+            Types.PlacedInServiceDate = startDate
+            Types.PropertyClass = Calculations.classifyAsset terms.EquipmentDescription
+            Types.Convention = Types.Convention.HalfYear
+        }
+        
+        let depreciationSchedule = Calculations.generateSchedule macrsAsset
+        
+        {
+            LeaseDetails = leaseDetails
+            PurchaseDepreciation = depreciationSchedule
+            LeaseSchedule = leaseSchedule
+            NetAdvantageToLeasing = None // Would implement full NPV analysis in complete version
+        }

--- a/src/EquipmentFinance/Lease.fs
+++ b/src/EquipmentFinance/Lease.fs
@@ -89,6 +89,108 @@ module Lease =
         RemainingLiability: int64<Cent>
     }
 
+    let private getScheduleShape (terms: EquipmentLeaseTerms) =
+        let periodsPerYear = terms.PaymentFrequency.PaymentsPerYear
+        if periodsPerYear <= 0 || 12 % periodsPerYear <> 0 then
+            invalidArg (nameof terms.PaymentFrequency) "Payment frequency must correspond to a whole number of months per payment period."
+
+        let monthsPerPeriod = 12 / periodsPerYear
+        if terms.TermMonths <= 0 then invalidArg (nameof terms.TermMonths) "TermMonths must be > 0."
+        if terms.TermMonths % monthsPerPeriod <> 0 then
+            invalidArg (nameof terms.TermMonths) "TermMonths must be an exact multiple of the selected payment interval."
+
+        periodsPerYear, monthsPerPeriod, terms.TermMonths / monthsPerPeriod
+
+    let private validateTerms (terms: EquipmentLeaseTerms) =
+        let _, _, _ = getScheduleShape terms
+        if terms.FairMarketValue <= 0L<Cent> then invalidArg (nameof terms.FairMarketValue) "FairMarketValue must be > 0."
+        if terms.UpfrontPayment < 0L<Cent> then invalidArg (nameof terms.UpfrontPayment) "UpfrontPayment must be >= 0."
+        if terms.UpfrontPayment >= terms.FairMarketValue then invalidArg (nameof terms.UpfrontPayment) "UpfrontPayment must be < FairMarketValue."
+        if terms.ResidualValue < 0L<Cent> then invalidArg (nameof terms.ResidualValue) "ResidualValue must be >= 0."
+        if terms.ResidualValue >= terms.FairMarketValue then invalidArg (nameof terms.ResidualValue) "ResidualValue must be < FairMarketValue."
+        if terms.LeasePayment < 0L<Cent> then invalidArg (nameof terms.LeasePayment) "LeasePayment must be >= 0."
+
+    let private periodRate (terms: EquipmentLeaseTerms) (periodsPerYear: int) =
+        match terms.ImplicitRate with
+        | Interest.Rate.Zero -> 0m
+        | Interest.Rate.Annual (Percent rate) -> rate / 100m / decimal periodsPerYear
+        | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / decimal periodsPerYear
+
+    let private buildScheduleCore (terms: EquipmentLeaseTerms) =
+        validateTerms terms
+
+        let periodsPerYear, monthsPerPeriod, totalPeriods = getScheduleShape terms
+        let rate = periodRate terms periodsPerYear
+
+        let leasePayment =
+            if terms.LeasePayment > 0L<Cent> then terms.LeasePayment
+            else
+                let fairValue = Cent.toDecimal terms.FairMarketValue
+                let upfront = Cent.toDecimal terms.UpfrontPayment
+                let residual = Cent.toDecimal terms.ResidualValue
+                let financedPrincipal = fairValue - upfront
+                if financedPrincipal <= 0m then invalidArg "terms.UpfrontPayment" "Upfront payment >= fair value."
+                if residual >= fairValue then invalidArg "terms.ResidualValue" "Residual must be < fair value."
+
+                if rate = 0m then
+                    let paymentDec = (financedPrincipal - residual) / decimal totalPeriods
+                    if paymentDec <= 0m then invalidOp "Non-positive payment under zero-rate scenario."
+                    Cent.fromDecimal paymentDec
+                else
+                    let growth = pow (1m + rate) (decimal totalPeriods)
+                    let pvResidual = residual / growth
+                    let baseAmount = financedPrincipal - pvResidual
+                    if baseAmount <= 0m then invalidOp "Discounted residual >= financed principal."
+                    let denom = 1m - 1m / growth
+                    if denom = 0m then invalidOp "Denominator collapsed (rate too small / overflow)."
+                    let paymentDec = baseAmount * rate / denom
+                    if paymentDec <= 0m then invalidOp "Computed payment is non-positive."
+                    Cent.fromDecimal paymentDec
+
+        let rec generateSchedule paymentNum liability acc =
+            if paymentNum > totalPeriods then
+                acc |> List.rev |> Array.ofList
+            else
+                let interestPortion, principalPortion, paymentAmount, newLiability =
+                    if terms.LeaseType = LeaseType.OperatingLease then
+                        0L<Cent>, 0L<Cent>, leasePayment, 0L<Cent>
+                    else
+                        let interest =
+                            decimal liability * rate * 1m<Cent>
+                            |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+
+                        let scheduledPrincipal = leasePayment - interest
+                        if scheduledPrincipal < 0L<Cent> then
+                            invalidArg (nameof terms.LeasePayment) "Lease payment must cover at least the period interest."
+                        let remainingPrincipalBeforeResidual = max 0L<Cent> (liability - terms.ResidualValue)
+                        let principal =
+                            if paymentNum = totalPeriods then
+                                remainingPrincipalBeforeResidual
+                            else
+                                min scheduledPrincipal remainingPrincipalBeforeResidual
+                        if terms.LeasePayment > 0L<Cent> && principal > scheduledPrincipal then
+                            invalidArg (nameof terms.LeasePayment) "LeasePayment is too low to amortize to the stated residual by maturity."
+                        let payment = interest + principal
+                        let remaining = liability - principal
+                        interest, principal, payment, remaining
+
+                let item = {
+                    PaymentNumber = paymentNum
+                    PaymentDate = DateDay.Date(2000, 1, 1).AddMonths(paymentNum * monthsPerPeriod)
+                    PaymentAmount = paymentAmount
+                    PrincipalPortion = principalPortion
+                    InterestPortion = interestPortion
+                    RemainingLiability = newLiability
+                }
+
+                generateSchedule (paymentNum + 1) newLiability (item :: acc)
+
+        let initialLiability =
+            if terms.LeaseType = LeaseType.OperatingLease then 0L<Cent>
+            else terms.FairMarketValue - terms.UpfrontPayment
+
+        leasePayment, periodsPerYear, monthsPerPeriod, totalPeriods, rate, generateSchedule 1 initialLiability []
+
     /// Calculate level lease payment with optional residual (balloon)
     /// Assumptions:
     /// - All incoming monetary values are int64<Cent>
@@ -96,52 +198,17 @@ module Lease =
     /// - ResidualValue discounted over total periods
     /// - Interest.Rate.Annual is nominal annual; divided by payments/year
     let calculateLeasePayment (terms: EquipmentLeaseTerms) : int64<Cent> =
-        let periodsPerYear = terms.PaymentFrequency.PaymentsPerYear
-        let totalPeriods = terms.TermMonths * periodsPerYear / 12
-        if totalPeriods <= 0 then invalidArg (nameof terms.TermMonths) "Computed total periods <= 0."
-
-        let periodRate =
-            match terms.ImplicitRate with
-            | Interest.Rate.Zero -> 0m
-            | Interest.Rate.Annual (Calculation.Percent p) ->
-                p / 100m / decimal periodsPerYear
-            | Interest.Rate.Daily (Calculation.Percent p) ->
-                // Interpret as nominal daily simple rate -> nominal annual -> per-period
-                (p / 100m) * 365m / decimal periodsPerYear
-
-        let fairValue = Cent.toDecimal terms.FairMarketValue
-        let upfront   = Cent.toDecimal terms.UpfrontPayment
-        let residual  = Cent.toDecimal terms.ResidualValue
-
-        let financedPrincipal = fairValue - upfront
-        if financedPrincipal <= 0m then invalidArg "terms.UpfrontPayment" "Upfront payment >= fair value."
-        if residual >= fairValue then invalidArg "terms.ResidualValue" "Residual must be < fair value."
-
-        if periodRate = 0m then
-            // Zero-rate linear repayment less residual
-            let paymentDec = (financedPrincipal - residual) / decimal totalPeriods
-            if paymentDec <= 0m then invalidOp "Non-positive payment under zero-rate scenario."
-            Cent.fromDecimal paymentDec
-        else
-            let growth = pow (1m + periodRate) (decimal totalPeriods)
-            let pvResidual = residual / growth
-            let baseAmount = financedPrincipal - pvResidual
-            if baseAmount <= 0m then invalidOp "Discounted residual >= financed principal."
-            let denom = 1m - 1m / growth
-            if denom = 0m then invalidOp "Denominator collapsed (rate too small / overflow)."
-            let paymentDec = baseAmount * periodRate / denom
-            if paymentDec <= 0m then invalidOp "Computed payment is non-positive."
-            Cent.fromDecimal paymentDec
+        buildScheduleCore terms |> fun (leasePayment, _, _, _, _, _) -> leasePayment
 
     /// Calculate lease payment details
     let calculateLeaseDetails (terms: EquipmentLeaseTerms) : LeaseCalculation =
+        validateTerms terms
         let leasePayment = 
             if terms.LeasePayment > 0L<Cent> then terms.LeasePayment 
             else calculateLeasePayment terms
-        
-        let periodsPerYear = terms.PaymentFrequency.PaymentsPerYear
-        let totalPeriods = terms.TermMonths * periodsPerYear / 12
-        let totalPayments = leasePayment * int64 totalPeriods + terms.UpfrontPayment
+
+        let _, periodsPerYear, _, _, rate, schedule = buildScheduleCore terms
+        let totalPayments = (schedule |> Array.sumBy (fun item -> item.PaymentAmount)) + terms.UpfrontPayment
         
         let totalCost = 
             match terms.PurchaseOption with
@@ -149,18 +216,12 @@ module Lease =
             | None -> totalPayments
         
         // Calculate present value of lease payments
-        let periodRate = 
-            match terms.ImplicitRate with
-            | Interest.Rate.Zero -> 0m
-            | Interest.Rate.Annual (Percent rate) -> rate / 100m / decimal periodsPerYear
-            | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / decimal periodsPerYear
-        
         let presentValue = 
-            if periodRate = 0m then
+            if rate = 0m then
                 totalPayments
             else
-                let pv = [1..totalPeriods]
-                         |> List.sumBy (fun period -> decimal leasePayment / pow (1m + periodRate) (decimal period))
+                let pv = schedule
+                         |> Array.sumBy (fun item -> decimal item.PaymentAmount / pow (1m + rate) (decimal item.PaymentNumber))
                          |> (+) (decimal terms.UpfrontPayment)
                          |> (*) 1m<Cent>
                 Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero) pv
@@ -181,63 +242,11 @@ module Lease =
 
     /// Generate lease payment schedule
     let generateLeaseSchedule (terms: EquipmentLeaseTerms) (startDate: DateDay.Date) : LeaseScheduleItem array =
-        let leasePayment = 
-            if terms.LeasePayment > 0L<Cent> then terms.LeasePayment 
-            else calculateLeasePayment terms
-        
-        let periodsPerYear = terms.PaymentFrequency.PaymentsPerYear
-        let totalPeriods = terms.TermMonths * periodsPerYear / 12
-        let periodRate = 
-            match terms.ImplicitRate with
-            | Interest.Rate.Zero -> 0m
-            | Interest.Rate.Annual (Percent rate) -> rate / 100m / decimal periodsPerYear
-            | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / decimal periodsPerYear
-        
-        let monthsPerPeriod = 12 / periodsPerYear
-        
-        let rec generateSchedule paymentNum currentDate liability acc =
-            if paymentNum > totalPeriods then
-                acc |> List.rev |> Array.ofList
-            else
-                let interestPortion = 
-                    if terms.LeaseType = LeaseType.OperatingLease then
-                        0L<Cent> // Operating leases don't split principal/interest
-                    else
-                        decimal liability * periodRate * 1m<Cent>
-                        |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
-                
-                let principalPortion = 
-                    if terms.LeaseType = LeaseType.OperatingLease then
-                        0L<Cent> // Operating leases don't split principal/interest
-                    else
-                        leasePayment - interestPortion
-                
-                let newLiability = 
-                    if terms.LeaseType = LeaseType.OperatingLease then
-                        liability // No liability reduction for operating leases
-                    else
-                        liability - principalPortion
-                
-                let paymentDate = startDate.AddMonths(paymentNum * monthsPerPeriod)
-                
-                let item = {
-                    PaymentNumber = paymentNum
-                    PaymentDate = paymentDate
-                    PaymentAmount = leasePayment
-                    PrincipalPortion = principalPortion
-                    InterestPortion = interestPortion
-                    RemainingLiability = newLiability
-                }
-                
-                generateSchedule (paymentNum + 1) paymentDate newLiability (item :: acc)
-        
-        let initialLiability = 
-            if terms.LeaseType = LeaseType.OperatingLease then
-                terms.FairMarketValue // For display purposes
-            else
-                terms.FairMarketValue - terms.UpfrontPayment
-        
-        generateSchedule 1 startDate initialLiability []
+        let _, _, monthsPerPeriod, _, _, schedule = buildScheduleCore terms
+
+        schedule
+        |> Array.map (fun item ->
+            { item with PaymentDate = startDate.AddMonths(item.PaymentNumber * monthsPerPeriod) })
 
     /// Analyze lease vs buy decision
     type LeaseVsBuyAnalysis = {

--- a/src/EquipmentFinance/Lease.fs
+++ b/src/EquipmentFinance/Lease.fs
@@ -9,7 +9,7 @@ open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
 module Lease =
 
     /// Simple power function for financial calculations
-    let private pow (base': decimal) (power: decimal) = 
+    let private pow (base': decimal) (power: decimal) =
         decimal (Math.Pow(double base', double power))
 
     /// Type of lease for equipment financing
@@ -18,6 +18,12 @@ module Lease =
         | OperatingLease    // Off-balance-sheet, lessor retains ownership
         | FinanceLease      // On-balance-sheet, lessee assumes ownership risks
         | CapitalLease      // Similar to finance lease under older accounting standards
+
+    /// Timing of lease payments within each period
+    [<Struct; RequireQualifiedAccess>]
+    type PaymentTiming =
+        | InArrears         // payment at the end of each period (annuity-immediate)
+        | InAdvance         // payment at the start of each period (annuity-due; usual for equipment leases)
 
     /// Lease payment frequency
     [<Struct; RequireQualifiedAccess>]
@@ -47,8 +53,14 @@ module Lease =
         LeaseType: LeaseType
         /// Payment frequency
         PaymentFrequency: PaymentFrequency
-        /// Lease payment amount
+        /// Timing of payments within each period. Equipment leases are typically InAdvance;
+        /// InArrears matches an ordinary loan-style annuity.
+        PaymentTiming: PaymentTiming
+        /// Lease payment amount excluding any PeriodicFee (0 to have it calculated from the other terms)
         LeasePayment: int64<Cent>
+        /// Optional recurring fee (e.g. service or administration fee) charged on top of
+        /// every payment; shown separately as FeePortion in the schedule
+        PeriodicFee: int64<Cent> option
         /// Any upfront payment or security deposit
         UpfrontPayment: int64<Cent>
         /// Residual value at end of lease term
@@ -61,14 +73,17 @@ module Lease =
 
     /// Lease payment calculation result
     type LeaseCalculation = {
-        /// The periodic lease payment
+        /// The periodic lease payment (excluding any PeriodicFee)
         LeasePayment: int64<Cent>
-        /// Total payments over the lease term
+        /// Total payments over the lease term, including any recurring fees
         TotalPayments: int64<Cent>
+        /// Total recurring fees paid over the lease term
+        TotalFees: int64<Cent>
         /// Total cost of leasing vs buying
         TotalCost: int64<Cent>
-        /// The annual percentage rate equivalent
-        AprEquivalent: Percent
+        /// The nominal annual rate implicit in the lease.
+        /// Note: this is NOT an effective APR; no compounding or fee effects are included.
+        NominalAnnualRate: Percent
         /// Present value of lease payments
         PresentValue: int64<Cent>
     }
@@ -79,12 +94,14 @@ module Lease =
         PaymentNumber: int
         /// Payment due date
         PaymentDate: DateDay.Date
-        /// The lease payment amount
+        /// The lease payment amount (rental + fee)
         PaymentAmount: int64<Cent>
         /// Principal portion (for finance leases)
         PrincipalPortion: int64<Cent>
         /// Interest portion (for finance leases)
         InterestPortion: int64<Cent>
+        /// Recurring fee portion of payment
+        FeePortion: int64<Cent>
         /// Remaining lease liability (for finance leases)
         RemainingLiability: int64<Cent>
     }
@@ -109,6 +126,9 @@ module Lease =
         if terms.ResidualValue < 0L<Cent> then invalidArg (nameof terms.ResidualValue) "ResidualValue must be >= 0."
         if terms.ResidualValue >= terms.FairMarketValue then invalidArg (nameof terms.ResidualValue) "ResidualValue must be < FairMarketValue."
         if terms.LeasePayment < 0L<Cent> then invalidArg (nameof terms.LeasePayment) "LeasePayment must be >= 0."
+        match terms.PeriodicFee with
+        | Some fee when fee < 0L<Cent> -> invalidArg (nameof terms.PeriodicFee) "PeriodicFee must be >= 0 when provided."
+        | _ -> ()
 
     let private periodRate (terms: EquipmentLeaseTerms) (periodsPerYear: int) =
         match terms.ImplicitRate with
@@ -116,37 +136,59 @@ module Lease =
         | Interest.Rate.Annual (Percent rate) -> rate / 100m / decimal periodsPerYear
         | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / decimal periodsPerYear
 
+    /// The level rental that amortizes the financed principal exactly to the residual over the term
+    let private levelPaymentDec (financedPrincipal: decimal) (residual: decimal) (rate: decimal) (totalPeriods: int) (timing: PaymentTiming) =
+        if rate = 0m then
+            (financedPrincipal - residual) / decimal totalPeriods
+        else
+            let growth = pow (1m + rate) (decimal totalPeriods)
+            let pvResidual = residual / growth
+            let baseAmount = financedPrincipal - pvResidual
+            let denom = 1m - 1m / growth
+            if denom = 0m then invalidOp "Denominator collapsed (rate too small / overflow)."
+            let ordinary = baseAmount * rate / denom
+            match timing with
+            | PaymentTiming.InArrears -> ordinary
+            | PaymentTiming.InAdvance -> ordinary / (1m + rate)
+
     let private buildScheduleCore (terms: EquipmentLeaseTerms) =
         validateTerms terms
 
         let periodsPerYear, monthsPerPeriod, totalPeriods = getScheduleShape terms
         let rate = periodRate terms periodsPerYear
 
+        let financedPrincipal = Cent.toDecimal (terms.FairMarketValue - terms.UpfrontPayment)
+        let residualDec = Cent.toDecimal terms.ResidualValue
+
+        // the level rental consistent with the stated residual; used as the computed payment
+        // and quoted in error messages when a stated rental cannot land on the residual
+        let consistentRentalDec = levelPaymentDec financedPrincipal residualDec rate totalPeriods terms.PaymentTiming
+
         let leasePayment =
             if terms.LeasePayment > 0L<Cent> then terms.LeasePayment
             else
-                let fairValue = Cent.toDecimal terms.FairMarketValue
-                let upfront = Cent.toDecimal terms.UpfrontPayment
-                let residual = Cent.toDecimal terms.ResidualValue
-                let financedPrincipal = fairValue - upfront
                 if financedPrincipal <= 0m then invalidArg "terms.UpfrontPayment" "Upfront payment >= fair value."
-                if residual >= fairValue then invalidArg "terms.ResidualValue" "Residual must be < fair value."
+                if residualDec >= financedPrincipal then invalidOp "Discounted residual >= financed principal."
+                if consistentRentalDec <= 0m then invalidOp "Computed payment is non-positive."
+                Cent.fromDecimal consistentRentalDec
 
-                if rate = 0m then
-                    let paymentDec = (financedPrincipal - residual) / decimal totalPeriods
-                    if paymentDec <= 0m then invalidOp "Non-positive payment under zero-rate scenario."
-                    Cent.fromDecimal paymentDec
-                else
-                    let growth = pow (1m + rate) (decimal totalPeriods)
-                    let pvResidual = residual / growth
-                    let baseAmount = financedPrincipal - pvResidual
-                    if baseAmount <= 0m then invalidOp "Discounted residual >= financed principal."
-                    let denom = 1m - 1m / growth
-                    if denom = 0m then invalidOp "Denominator collapsed (rate too small / overflow)."
-                    let paymentDec = baseAmount * rate / denom
-                    if paymentDec <= 0m then invalidOp "Computed payment is non-positive."
-                    Cent.fromDecimal paymentDec
+        let residual = terms.ResidualValue
+        let fee = terms.PeriodicFee |> Option.defaultValue 0L<Cent>
+        let round' (d: decimal<Cent>) = Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero) d
+        // allow small rounding drift (schedule-length cents) before declaring the contract inconsistent
+        let floorTolerance = int64 totalPeriods * 1L<Cent>
 
+        let failTooHigh () =
+            invalidArg (nameof terms.LeasePayment)
+                $"LeasePayment {Cent.toDecimal leasePayment:N2} is too high to amortize exactly to the stated residual by maturity: the liability would fall below the residual before the final period. A consistent level rental is approximately {consistentRentalDec:N2}."
+
+        let failTooLow (plugPayment: int64<Cent>) =
+            invalidArg (nameof terms.LeasePayment)
+                $"LeasePayment {Cent.toDecimal leasePayment:N2} is too low to amortize to the stated residual by maturity: the final payment would be {Cent.toDecimal plugPayment:N2}. The minimum consistent level rental is approximately {consistentRentalDec:N2}."
+
+        // The stated rental is charged verbatim every period; interest accrues on the outstanding
+        // liability and the FINAL period is the plug that lands exactly on the residual
+        // (final principal = liability - residual). Inconsistent contracts are rejected.
         let rec generateSchedule paymentNum liability acc =
             if paymentNum > totalPeriods then
                 acc |> List.rev |> Array.ofList
@@ -155,31 +197,51 @@ module Lease =
                     if terms.LeaseType = LeaseType.OperatingLease then
                         0L<Cent>, 0L<Cent>, leasePayment, 0L<Cent>
                     else
-                        let interest =
-                            decimal liability * rate * 1m<Cent>
-                            |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
-
-                        let scheduledPrincipal = leasePayment - interest
-                        if scheduledPrincipal < 0L<Cent> then
-                            invalidArg (nameof terms.LeasePayment) "Lease payment must cover at least the period interest."
-                        let remainingPrincipalBeforeResidual = max 0L<Cent> (liability - terms.ResidualValue)
-                        let principal =
-                            if paymentNum = totalPeriods then
-                                remainingPrincipalBeforeResidual
+                        let isFinal = paymentNum = totalPeriods
+                        match terms.PaymentTiming with
+                        | PaymentTiming.InArrears ->
+                            let interest = round' (decimal liability * rate * 1m<Cent>)
+                            if isFinal then
+                                let principal = liability - residual
+                                let payment = interest + principal
+                                if payment < 0L<Cent> then failTooHigh ()
+                                if terms.LeasePayment > 0L<Cent> && payment > leasePayment * 2L then failTooLow payment
+                                interest, principal, payment, residual
                             else
-                                min scheduledPrincipal remainingPrincipalBeforeResidual
-                        if terms.LeasePayment > 0L<Cent> && principal > scheduledPrincipal then
-                            invalidArg (nameof terms.LeasePayment) "LeasePayment is too low to amortize to the stated residual by maturity."
-                        let payment = interest + principal
-                        let remaining = liability - principal
-                        interest, principal, payment, remaining
+                                let principal = leasePayment - interest
+                                if principal < 0L<Cent> then
+                                    invalidArg (nameof terms.LeasePayment) "Lease payment must cover at least the period interest."
+                                let remaining = liability - principal
+                                if remaining < residual - floorTolerance then failTooHigh ()
+                                interest, principal, leasePayment, remaining
+                        | PaymentTiming.InAdvance ->
+                            // payment at the start of the period; interest accrues on the
+                            // post-payment balance and is settled within the same row, so the
+                            // liability evolves as L' = (L - payment) * (1 + rate)
+                            if isFinal then
+                                let principal = liability - residual
+                                let interest = round' (residualDec * rate / (1m + rate) * 100m<Cent>)
+                                let payment = interest + principal
+                                if payment < 0L<Cent> then failTooHigh ()
+                                if terms.LeasePayment > 0L<Cent> && payment > leasePayment * 2L then failTooLow payment
+                                interest, principal, payment, residual
+                            else
+                                if leasePayment > liability then failTooHigh ()
+                                let interest = round' (decimal (liability - leasePayment) * rate * 1m<Cent>)
+                                let principal = leasePayment - interest
+                                if principal < 0L<Cent> then
+                                    invalidArg (nameof terms.LeasePayment) "Lease payment must cover at least the period interest."
+                                let remaining = liability - principal
+                                if remaining < residual - floorTolerance then failTooHigh ()
+                                interest, principal, leasePayment, remaining
 
                 let item = {
                     PaymentNumber = paymentNum
                     PaymentDate = DateDay.Date(2000, 1, 1).AddMonths(paymentNum * monthsPerPeriod)
-                    PaymentAmount = paymentAmount
+                    PaymentAmount = paymentAmount + fee
                     PrincipalPortion = principalPortion
                     InterestPortion = interestPortion
+                    FeePortion = fee
                     RemainingLiability = newLiability
                 }
 
@@ -197,46 +259,51 @@ module Lease =
     /// - UpfrontPayment reduces financed amount
     /// - ResidualValue discounted over total periods
     /// - Interest.Rate.Annual is nominal annual; divided by payments/year
+    /// - InAdvance payments use the annuity-due adjustment (ordinary payment / (1 + period rate))
     let calculateLeasePayment (terms: EquipmentLeaseTerms) : int64<Cent> =
         buildScheduleCore terms |> fun (leasePayment, _, _, _, _, _) -> leasePayment
 
-    /// Calculate lease payment details
+    /// Calculate lease payment details.
+    /// Totals and present value are computed from the contractual schedule: the stated rental
+    /// every period plus the final plug payment that lands exactly on the residual.
     let calculateLeaseDetails (terms: EquipmentLeaseTerms) : LeaseCalculation =
-        validateTerms terms
-        let leasePayment = 
-            if terms.LeasePayment > 0L<Cent> then terms.LeasePayment 
-            else calculateLeasePayment terms
-
-        let _, periodsPerYear, _, _, rate, schedule = buildScheduleCore terms
+        let leasePayment, _, _, _, rate, schedule = buildScheduleCore terms
         let totalPayments = (schedule |> Array.sumBy (fun item -> item.PaymentAmount)) + terms.UpfrontPayment
-        
-        let totalCost = 
+        let totalFees = schedule |> Array.sumBy (fun item -> item.FeePortion)
+
+        let totalCost =
             match terms.PurchaseOption with
             | Some purchasePrice -> totalPayments + purchasePrice
             | None -> totalPayments
-        
-        // Calculate present value of lease payments
-        let presentValue = 
+
+        // Calculate present value of lease payments (in-advance payments fall at the start of
+        // each period, so they are discounted one period less)
+        let presentValue =
             if rate = 0m then
                 totalPayments
             else
+                let discountPeriods (item: LeaseScheduleItem) =
+                    match terms.PaymentTiming with
+                    | PaymentTiming.InArrears -> decimal item.PaymentNumber
+                    | PaymentTiming.InAdvance -> decimal (item.PaymentNumber - 1)
                 let pv = schedule
-                         |> Array.sumBy (fun item -> decimal item.PaymentAmount / pow (1m + rate) (decimal item.PaymentNumber))
+                         |> Array.sumBy (fun item -> decimal item.PaymentAmount / pow (1m + rate) (discountPeriods item))
                          |> (+) (decimal terms.UpfrontPayment)
                          |> (*) 1m<Cent>
                 Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero) pv
-        
-        let aprEquivalent = 
+
+        let nominalAnnualRate =
             match terms.ImplicitRate with
             | Interest.Rate.Zero -> Percent 0m
             | Interest.Rate.Annual percent -> percent
             | Interest.Rate.Daily (Percent rate) -> Percent (rate * 365m)
-        
+
         {
             LeasePayment = leasePayment
             TotalPayments = totalPayments
+            TotalFees = totalFees
             TotalCost = totalCost
-            AprEquivalent = aprEquivalent
+            NominalAnnualRate = nominalAnnualRate
             PresentValue = presentValue
         }
 
@@ -244,9 +311,13 @@ module Lease =
     let generateLeaseSchedule (terms: EquipmentLeaseTerms) (startDate: DateDay.Date) : LeaseScheduleItem array =
         let _, _, monthsPerPeriod, _, _, schedule = buildScheduleCore terms
 
+        let paymentDate (paymentNumber: int) =
+            match terms.PaymentTiming with
+            | PaymentTiming.InArrears -> startDate.AddMonths(paymentNumber * monthsPerPeriod)
+            | PaymentTiming.InAdvance -> startDate.AddMonths((paymentNumber - 1) * monthsPerPeriod)
+
         schedule
-        |> Array.map (fun item ->
-            { item with PaymentDate = startDate.AddMonths(item.PaymentNumber * monthsPerPeriod) })
+        |> Array.map (fun item -> { item with PaymentDate = paymentDate item.PaymentNumber })
 
     /// Analyze lease vs buy decision
     type LeaseVsBuyAnalysis = {
@@ -256,28 +327,69 @@ module Lease =
         PurchaseDepreciation: Types.DepreciationYear list
         /// Lease payment schedule
         LeaseSchedule: LeaseScheduleItem array
-        /// Net advantage to leasing (positive means leasing is better)
-        NetAdvantageToLeasing: int64<Cent> option
+        /// Net advantage to leasing: NPV(cost of buying) - NPV(cost of leasing), both
+        /// discounted at the supplied annual discount rate (positive means leasing is better).
+        /// Buying costs the fair market value; if the lease has no purchase option the buyer
+        /// additionally retains the residual value at term end (credited at present value),
+        /// whereas with a purchase option both scenarios end in ownership so the terminal
+        /// value cancels and the option price is a leasing cost.
+        /// A simple pre-tax NPV; no tax effects are modelled.
+        NetAdvantageToLeasing: int64<Cent>
+        /// True when the equipment description did not match any known asset-class keyword
+        /// and the default FiveYear MACRS class was assumed for the depreciation schedule
+        AssetClassAssumed: bool
     }
 
-    /// Perform lease vs buy analysis
-    let analyzeLeaseVsBuy (terms: EquipmentLeaseTerms) (startDate: DateDay.Date) : LeaseVsBuyAnalysis =
+    /// Perform lease vs buy analysis.
+    /// annualDiscountRate is the rate used to discount both alternatives for NetAdvantageToLeasing.
+    let analyzeLeaseVsBuy (terms: EquipmentLeaseTerms) (startDate: DateDay.Date) (annualDiscountRate: Percent) : LeaseVsBuyAnalysis =
         let leaseDetails = calculateLeaseDetails terms
         let leaseSchedule = generateLeaseSchedule terms startDate
-        
-        // Create depreciation schedule for purchase scenario
+
+        let periodsPerYear, _, totalPeriods = getScheduleShape terms
+        let periodDiscount = Percent.toDecimal annualDiscountRate / decimal periodsPerYear
+        let discountFactor (periods: decimal) = pow (1m + periodDiscount) periods
+
+        let netAdvantageToLeasing =
+            let discountPeriods (item: LeaseScheduleItem) =
+                match terms.PaymentTiming with
+                | PaymentTiming.InArrears -> decimal item.PaymentNumber
+                | PaymentTiming.InAdvance -> decimal (item.PaymentNumber - 1)
+            let leasePaymentsPv =
+                leaseSchedule
+                |> Array.sumBy (fun item -> decimal item.PaymentAmount / discountFactor (discountPeriods item))
+            let leaseCostPv =
+                decimal terms.UpfrontPayment
+                + leasePaymentsPv
+                + (match terms.PurchaseOption with
+                   | Some price -> decimal price / discountFactor (decimal totalPeriods)
+                   | None -> 0m)
+            let buyCostPv =
+                match terms.PurchaseOption with
+                // without a purchase option the lessee hands the equipment back, so buying
+                // retains the residual value at term end; with one, both scenarios end in
+                // ownership and the terminal value cancels
+                | None -> decimal terms.FairMarketValue - decimal terms.ResidualValue / discountFactor (decimal totalPeriods)
+                | Some _ -> decimal terms.FairMarketValue
+            (buyCostPv - leaseCostPv) * 1m<Cent>
+            |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+
+        // Create depreciation schedule for the purchase scenario; if the description is not
+        // recognized, FiveYear is assumed and the assumption is surfaced via AssetClassAssumed
+        let classified = Calculations.tryClassifyAsset terms.EquipmentDescription
         let macrsAsset = {
             Types.CostBasis = terms.FairMarketValue
             Types.PlacedInServiceDate = startDate
-            Types.PropertyClass = Calculations.classifyAsset terms.EquipmentDescription
+            Types.PropertyClass = classified |> Option.defaultValue Types.AssetClass.FiveYear
             Types.Convention = Types.Convention.HalfYear
         }
-        
+
         let depreciationSchedule = Calculations.generateSchedule macrsAsset
-        
+
         {
             LeaseDetails = leaseDetails
             PurchaseDepreciation = depreciationSchedule
             LeaseSchedule = leaseSchedule
-            NetAdvantageToLeasing = None // Would implement full NPV analysis in complete version
+            NetAdvantageToLeasing = netAdvantageToLeasing
+            AssetClassAssumed = classified.IsNone
         }

--- a/src/EquipmentFinance/Loan.fs
+++ b/src/EquipmentFinance/Loan.fs
@@ -14,7 +14,7 @@ module Loan =
 
     /// Terms and conditions for an equipment loan
     type EquipmentLoanTerms = {
-        /// The principal amount of the loan
+        /// The financed principal amount of the loan, net of any down payment
         Principal: int64<Cent>
         /// The annual interest rate
         InterestRate: Interest.Rate
@@ -60,31 +60,77 @@ module Loan =
         RemainingBalance: int64<Cent>
     }
 
+    let private validateTerms (terms: EquipmentLoanTerms) =
+        if terms.Principal <= 0L<Cent> then invalidArg (nameof terms.Principal) "Principal must be > 0."
+        if terms.TermMonths <= 0 then invalidArg (nameof terms.TermMonths) "TermMonths must be > 0."
+        if terms.EquipmentCost <= 0L<Cent> then invalidArg (nameof terms.EquipmentCost) "EquipmentCost must be > 0."
+        if terms.DownPayment < 0L<Cent> then invalidArg (nameof terms.DownPayment) "DownPayment must be >= 0."
+        if terms.ResidualValue < 0L<Cent> then invalidArg (nameof terms.ResidualValue) "ResidualValue must be >= 0."
+        if terms.ResidualValue >= terms.Principal then invalidArg (nameof terms.ResidualValue) "ResidualValue must be less than Principal."
+
+        match terms.MonthlyPayment with
+        | Some payment when payment <= 0L<Cent> -> invalidArg (nameof terms.MonthlyPayment) "MonthlyPayment must be > 0 when provided."
+        | _ -> ()
+
+    let private monthlyRate (interestRate: Interest.Rate) =
+        match interestRate with
+        | Interest.Rate.Zero -> 0m
+        | Interest.Rate.Annual (Percent rate) -> rate / 100m / 12m
+        | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / 12m
+
+    let private buildScheduleCore (terms: EquipmentLoanTerms) =
+        validateTerms terms
+
+        let payment =
+            match terms.MonthlyPayment with
+            | Some monthlyPayment -> monthlyPayment
+            | None ->
+                let rate = monthlyRate terms.InterestRate
+                if rate = 0m then
+                    let amortizedPrincipal = Cent.toDecimal (terms.Principal - terms.ResidualValue)
+                    Cent.fromDecimal (amortizedPrincipal / decimal terms.TermMonths)
+                else
+                    let growthFactor = pow (1m + rate) (decimal terms.TermMonths)
+                    let residualPresentValue = decimal terms.ResidualValue / growthFactor
+                    let amortizedPrincipal = decimal terms.Principal - residualPresentValue
+                    let numerator = amortizedPrincipal * rate * growthFactor
+                    let denominator = growthFactor - 1m
+                    let installment = numerator / denominator
+                    installment * 1m<Cent> |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+
+        let rate = monthlyRate terms.InterestRate
+
+        let rec generateSchedule paymentNum balance acc =
+            if paymentNum > terms.TermMonths then
+                acc |> List.rev |> Array.ofList
+            else
+                let interestPayment = 
+                    decimal balance * rate * 1m<Cent>
+                    |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+
+                let paymentAmount, principalPayment =
+                    if paymentNum = terms.TermMonths then
+                        let finalPayment = balance + interestPayment
+                        finalPayment, balance
+                    else
+                        let principal = payment - interestPayment
+                        if principal <= 0L<Cent> then
+                            invalidArg (nameof terms.MonthlyPayment) "Monthly payment must exceed periodic interest."
+                        payment, principal
+
+                let newBalance = balance - principalPayment
+                generateSchedule (paymentNum + 1) newBalance ((paymentNum, paymentAmount, principalPayment, interestPayment, newBalance) :: acc)
+
+        payment, generateSchedule 1 terms.Principal []
+
     /// Calculate monthly payment for an equipment loan
     let calculateMonthlyPayment (terms: EquipmentLoanTerms) : int64<Cent> =
-        match terms.MonthlyPayment with
-        | Some payment -> payment
-        | None ->
-            let monthlyRate = 
-                match terms.InterestRate with
-                | Interest.Rate.Zero -> 0m
-                | Interest.Rate.Annual (Percent rate) -> rate / 100m / 12m
-                | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / 12m
-            
-            if monthlyRate = 0m then
-                // No interest, just divide principal by term
-                terms.Principal / int64 terms.TermMonths
-            else
-                let loanAmount = terms.Principal - terms.ResidualValue
-                let numerator = decimal loanAmount * monthlyRate * pow (1m + monthlyRate) (decimal terms.TermMonths)
-                let denominator = pow (1m + monthlyRate) (decimal terms.TermMonths) - 1m
-                let payment = numerator / denominator
-                payment * 1m<Cent> |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+        buildScheduleCore terms |> fst
 
     /// Calculate payment details for an equipment loan
     let calculatePaymentDetails (terms: EquipmentLoanTerms) : PaymentCalculation =
-        let monthlyPayment = calculateMonthlyPayment terms
-        let totalPayments = monthlyPayment * int64 terms.TermMonths + terms.ResidualValue
+        let monthlyPayment, schedule = buildScheduleCore terms
+        let totalPayments = schedule |> Array.sumBy (fun (_, paymentAmount, _, _, _) -> paymentAmount)
         let totalInterest = totalPayments - terms.Principal
         
         // Simplified APR calculation (actual APR would require iterative calculation)
@@ -103,43 +149,18 @@ module Loan =
 
     /// Generate loan amortization schedule
     let generateAmortizationSchedule (terms: EquipmentLoanTerms) (startDate: DateDay.Date) : AmortizationItem array =
-        let monthlyPayment = calculateMonthlyPayment terms
-        let monthlyRate = 
-            match terms.InterestRate with
-            | Interest.Rate.Zero -> 0m
-            | Interest.Rate.Annual (Percent rate) -> rate / 100m / 12m
-            | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / 12m
-        
-        let rec generateSchedule paymentNum currentDate balance acc =
-            if paymentNum > terms.TermMonths then
-                acc |> List.rev |> Array.ofList
-            else
-                let interestPayment = 
-                    decimal balance * monthlyRate * 1m<Cent>
-                    |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
-                
-                let principalPayment = 
-                    if paymentNum = terms.TermMonths then
-                        // Final payment: pay remaining balance minus residual
-                        balance - terms.ResidualValue
-                    else
-                        monthlyPayment - interestPayment
-                
-                let newBalance = balance - principalPayment
-                let paymentDate = startDate.AddMonths(paymentNum)
-                
-                let item = {
-                    PaymentNumber = paymentNum
-                    PaymentDate = paymentDate
-                    PaymentAmount = if paymentNum = terms.TermMonths then principalPayment + interestPayment else monthlyPayment
-                    PrincipalPayment = principalPayment
-                    InterestPayment = interestPayment
-                    RemainingBalance = newBalance
-                }
-                
-                generateSchedule (paymentNum + 1) paymentDate newBalance (item :: acc)
-        
-        generateSchedule 1 startDate terms.Principal []
+        let _, schedule = buildScheduleCore terms
+
+        schedule
+        |> Array.map (fun (paymentNum, paymentAmount, principalPayment, interestPayment, remainingBalance) ->
+            {
+                PaymentNumber = paymentNum
+                PaymentDate = startDate.AddMonths(paymentNum)
+                PaymentAmount = paymentAmount
+                PrincipalPayment = principalPayment
+                InterestPayment = interestPayment
+                RemainingBalance = remainingBalance
+            })
 
     /// Analyze equipment loan with depreciation considerations
     type LoanAnalysis = {

--- a/src/EquipmentFinance/Loan.fs
+++ b/src/EquipmentFinance/Loan.fs
@@ -9,7 +9,7 @@ open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
 module Loan =
 
     /// Simple power function for financial calculations
-    let private pow (base': decimal) (power: decimal) = 
+    let private pow (base': decimal) (power: decimal) =
         decimal (Math.Pow(double base', double power))
 
     /// Terms and conditions for an equipment loan
@@ -20,28 +20,35 @@ module Loan =
         InterestRate: Interest.Rate
         /// The loan term in months
         TermMonths: int
-        /// The monthly payment amount (if known)
+        /// The monthly payment amount excluding any MonthlyFee (if known)
         MonthlyPayment: int64<Cent> option
+        /// Optional recurring fee (e.g. service or administration fee) charged on top of
+        /// every payment; shown separately as FeePayment in the schedule
+        MonthlyFee: int64<Cent> option
         /// The equipment being financed
         EquipmentDescription: string
         /// The cost of the equipment
         EquipmentCost: int64<Cent>
         /// Down payment made on the equipment
         DownPayment: int64<Cent>
-        /// Residual value at end of loan term
+        /// Residual value at end of loan term, payable as a balloon with the final payment.
+        /// May equal Principal for an interest-only balloon structure.
         ResidualValue: int64<Cent>
     }
 
     /// Loan payment calculation result
     type PaymentCalculation = {
-        /// The calculated monthly payment
+        /// The calculated monthly payment (principal + interest, excluding any MonthlyFee)
         MonthlyPayment: int64<Cent>
-        /// Total payments over the loan term
+        /// Total payments over the loan term, including any recurring fees
         TotalPayments: int64<Cent>
         /// Total interest paid over the loan term
         TotalInterest: int64<Cent>
-        /// The annual percentage rate
-        Apr: Percent
+        /// Total recurring fees paid over the loan term
+        TotalFees: int64<Cent>
+        /// The nominal annual interest rate used for the schedule.
+        /// Note: this is NOT an effective APR; no compounding or fee effects are included.
+        NominalAnnualRate: Percent
     }
 
     /// Loan amortization schedule item
@@ -50,14 +57,20 @@ module Loan =
         PaymentNumber: int
         /// Payment due date
         PaymentDate: DateDay.Date
-        /// The payment amount
+        /// The payment amount (principal + interest + fee, including any balloon in the final payment)
         PaymentAmount: int64<Cent>
-        /// Principal portion of payment
+        /// Principal portion of payment (includes the balloon amount in the final payment)
         PrincipalPayment: int64<Cent>
         /// Interest portion of payment
         InterestPayment: int64<Cent>
-        /// Remaining principal balance
+        /// Recurring fee portion of payment
+        FeePayment: int64<Cent>
+        /// Remaining principal balance (includes the residual until the final payment clears it)
         RemainingBalance: int64<Cent>
+        /// The residual (balloon) amount included in this payment. Zero except in the final
+        /// payment of a loan with a residual value, where it distinguishes the balloon from
+        /// ordinary amortization and rounding drift.
+        BalloonAmount: int64<Cent>
     }
 
     let private validateTerms (terms: EquipmentLoanTerms) =
@@ -66,10 +79,15 @@ module Loan =
         if terms.EquipmentCost <= 0L<Cent> then invalidArg (nameof terms.EquipmentCost) "EquipmentCost must be > 0."
         if terms.DownPayment < 0L<Cent> then invalidArg (nameof terms.DownPayment) "DownPayment must be >= 0."
         if terms.ResidualValue < 0L<Cent> then invalidArg (nameof terms.ResidualValue) "ResidualValue must be >= 0."
-        if terms.ResidualValue >= terms.Principal then invalidArg (nameof terms.ResidualValue) "ResidualValue must be less than Principal."
+        // ResidualValue = Principal is a legitimate interest-only balloon structure
+        if terms.ResidualValue > terms.Principal then invalidArg (nameof terms.ResidualValue) "ResidualValue must not exceed Principal."
 
         match terms.MonthlyPayment with
         | Some payment when payment <= 0L<Cent> -> invalidArg (nameof terms.MonthlyPayment) "MonthlyPayment must be > 0 when provided."
+        | _ -> ()
+
+        match terms.MonthlyFee with
+        | Some fee when fee < 0L<Cent> -> invalidArg (nameof terms.MonthlyFee) "MonthlyFee must be >= 0 when provided."
         | _ -> ()
 
     let private monthlyRate (interestRate: Interest.Rate) =
@@ -81,11 +99,21 @@ module Loan =
     let private buildScheduleCore (terms: EquipmentLoanTerms) =
         validateTerms terms
 
+        let rate = monthlyRate terms.InterestRate
+
         let payment =
             match terms.MonthlyPayment with
-            | Some monthlyPayment -> monthlyPayment
+            | Some monthlyPayment ->
+                // reject negative amortization: the payment must cover at least the first-period
+                // interest, which is the largest interest charge of the schedule
+                let firstInterest =
+                    decimal terms.Principal * rate * 1m<Cent>
+                    |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+                if monthlyPayment < firstInterest then
+                    invalidArg (nameof terms.MonthlyPayment)
+                        $"MonthlyPayment must cover at least the first-period interest ({Cent.toDecimal firstInterest:N2}) to avoid negative amortization."
+                monthlyPayment
             | None ->
-                let rate = monthlyRate terms.InterestRate
                 if rate = 0m then
                     let amortizedPrincipal = Cent.toDecimal (terms.Principal - terms.ResidualValue)
                     Cent.fromDecimal (amortizedPrincipal / decimal terms.TermMonths)
@@ -98,28 +126,35 @@ module Loan =
                     let installment = numerator / denominator
                     installment * 1m<Cent> |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
 
-        let rate = monthlyRate terms.InterestRate
+        let fee = terms.MonthlyFee |> Option.defaultValue 0L<Cent>
 
+        // The balance includes the residual until the final payment clears it as a balloon.
+        // Per-period principal is clamped to the remaining amortizable balance (balance - residual);
+        // if a supplied payment overpays, the schedule ends early rather than emitting
+        // zero or negative rows.
         let rec generateSchedule paymentNum balance acc =
-            if paymentNum > terms.TermMonths then
-                acc |> List.rev |> Array.ofList
+            let interestPayment =
+                decimal balance * rate * 1m<Cent>
+                |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+
+            let amortizable = balance - terms.ResidualValue
+            let scheduledPrincipal = payment - interestPayment
+
+            let isFinal =
+                paymentNum = terms.TermMonths
+                || (amortizable > 0L<Cent> && scheduledPrincipal >= amortizable)
+
+            if isFinal then
+                // final payment clears the remaining amortizable balance plus the residual balloon
+                let principalPayment = balance
+                let paymentAmount = interestPayment + principalPayment + fee
+                let item = (paymentNum, paymentAmount, principalPayment, interestPayment, fee, 0L<Cent>, terms.ResidualValue)
+                item :: acc |> List.rev |> Array.ofList
             else
-                let interestPayment = 
-                    decimal balance * rate * 1m<Cent>
-                    |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
-
-                let paymentAmount, principalPayment =
-                    if paymentNum = terms.TermMonths then
-                        let finalPayment = balance + interestPayment
-                        finalPayment, balance
-                    else
-                        let principal = payment - interestPayment
-                        if principal <= 0L<Cent> then
-                            invalidArg (nameof terms.MonthlyPayment) "Monthly payment must exceed periodic interest."
-                        payment, principal
-
+                let principalPayment = max 0L<Cent> (min scheduledPrincipal amortizable)
                 let newBalance = balance - principalPayment
-                generateSchedule (paymentNum + 1) newBalance ((paymentNum, paymentAmount, principalPayment, interestPayment, newBalance) :: acc)
+                let paymentAmount = interestPayment + principalPayment + fee
+                generateSchedule (paymentNum + 1) newBalance ((paymentNum, paymentAmount, principalPayment, interestPayment, fee, newBalance, 0L<Cent>) :: acc)
 
         payment, generateSchedule 1 terms.Principal []
 
@@ -130,36 +165,41 @@ module Loan =
     /// Calculate payment details for an equipment loan
     let calculatePaymentDetails (terms: EquipmentLoanTerms) : PaymentCalculation =
         let monthlyPayment, schedule = buildScheduleCore terms
-        let totalPayments = schedule |> Array.sumBy (fun (_, paymentAmount, _, _, _) -> paymentAmount)
-        let totalInterest = totalPayments - terms.Principal
-        
-        // Simplified APR calculation (actual APR would require iterative calculation)
-        let annualRate = 
+        let totalPayments = schedule |> Array.sumBy (fun (_, paymentAmount, _, _, _, _, _) -> paymentAmount)
+        let totalInterest = schedule |> Array.sumBy (fun (_, _, _, interestPayment, _, _, _) -> interestPayment)
+        let totalFees = schedule |> Array.sumBy (fun (_, _, _, _, feePayment, _, _) -> feePayment)
+
+        let annualRate =
             match terms.InterestRate with
             | Interest.Rate.Zero -> Percent 0m
             | Interest.Rate.Annual percent -> percent
             | Interest.Rate.Daily (Percent rate) -> Percent (rate * 365m)
-        
+
         {
             MonthlyPayment = monthlyPayment
             TotalPayments = totalPayments
             TotalInterest = totalInterest
-            Apr = annualRate
+            TotalFees = totalFees
+            NominalAnnualRate = annualRate
         }
 
-    /// Generate loan amortization schedule
+    /// Generate loan amortization schedule.
+    /// Note: if a supplied MonthlyPayment overpays, the schedule terminates early
+    /// (fewer periods than the nominal term) once the balance net of the residual is repaid.
     let generateAmortizationSchedule (terms: EquipmentLoanTerms) (startDate: DateDay.Date) : AmortizationItem array =
         let _, schedule = buildScheduleCore terms
 
         schedule
-        |> Array.map (fun (paymentNum, paymentAmount, principalPayment, interestPayment, remainingBalance) ->
+        |> Array.map (fun (paymentNum, paymentAmount, principalPayment, interestPayment, feePayment, remainingBalance, balloonAmount) ->
             {
                 PaymentNumber = paymentNum
                 PaymentDate = startDate.AddMonths(paymentNum)
                 PaymentAmount = paymentAmount
                 PrincipalPayment = principalPayment
                 InterestPayment = interestPayment
+                FeePayment = feePayment
                 RemainingBalance = remainingBalance
+                BalloonAmount = balloonAmount
             })
 
     /// Analyze equipment loan with depreciation considerations
@@ -170,28 +210,45 @@ module Loan =
         DepreciationSchedule: Types.DepreciationYear list
         /// Loan amortization schedule
         AmortizationSchedule: AmortizationItem array
-        /// Net present value analysis would go here in a full implementation
-        NetPresentValue: int64<Cent> option
+        /// Present value of all loan cash outflows (down payment plus every scheduled
+        /// payment, including any balloon and fees) discounted monthly at the supplied
+        /// annual discount rate. A simple pre-tax NPV; no tax effects are modelled.
+        NetPresentValue: int64<Cent>
+        /// True when the equipment description did not match any known asset-class keyword
+        /// and the default FiveYear MACRS class was assumed for the depreciation schedule
+        AssetClassAssumed: bool
     }
 
-    /// Perform comprehensive analysis of an equipment loan
-    let analyzeLoan (terms: EquipmentLoanTerms) (startDate: DateDay.Date) : LoanAnalysis =
+    /// Perform comprehensive analysis of an equipment loan.
+    /// annualDiscountRate is the rate used to discount the loan cash flows for NetPresentValue.
+    let analyzeLoan (terms: EquipmentLoanTerms) (startDate: DateDay.Date) (annualDiscountRate: Percent) : LoanAnalysis =
         let paymentDetails = calculatePaymentDetails terms
         let amortizationSchedule = generateAmortizationSchedule terms startDate
-        
-        // Create MACRS asset for depreciation analysis
+
+        let monthlyDiscount = Percent.toDecimal annualDiscountRate / 12m
+        let netPresentValue =
+            let paymentsPv =
+                amortizationSchedule
+                |> Array.sumBy (fun item -> decimal item.PaymentAmount / pow (1m + monthlyDiscount) (decimal item.PaymentNumber))
+            (decimal terms.DownPayment + paymentsPv) * 1m<Cent>
+            |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+
+        // Create MACRS asset for depreciation analysis; if the description is not recognized,
+        // FiveYear is assumed and the assumption is surfaced via AssetClassAssumed
+        let classified = Calculations.tryClassifyAsset terms.EquipmentDescription
         let macrsAsset = {
             Types.CostBasis = terms.EquipmentCost
             Types.PlacedInServiceDate = startDate
-            Types.PropertyClass = Calculations.classifyAsset terms.EquipmentDescription
+            Types.PropertyClass = classified |> Option.defaultValue Types.AssetClass.FiveYear
             Types.Convention = Types.Convention.HalfYear
         }
-        
+
         let depreciationSchedule = Calculations.generateSchedule macrsAsset
-        
+
         {
             PaymentDetails = paymentDetails
             DepreciationSchedule = depreciationSchedule
             AmortizationSchedule = amortizationSchedule
-            NetPresentValue = None // Would implement NPV calculation in full version
+            NetPresentValue = netPresentValue
+            AssetClassAssumed = classified.IsNone
         }

--- a/src/EquipmentFinance/Loan.fs
+++ b/src/EquipmentFinance/Loan.fs
@@ -1,0 +1,176 @@
+namespace FSharp.Finance.Personal.EquipmentFinance
+
+open System
+open FSharp.Finance.Personal
+open FSharp.Finance.Personal.Calculation
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
+
+/// Equipment loan calculations and analysis for equipment finance
+module Loan =
+
+    /// Simple power function for financial calculations
+    let private pow (base': decimal) (power: decimal) = 
+        decimal (Math.Pow(double base', double power))
+
+    /// Terms and conditions for an equipment loan
+    type EquipmentLoanTerms = {
+        /// The principal amount of the loan
+        Principal: int64<Cent>
+        /// The annual interest rate
+        InterestRate: Interest.Rate
+        /// The loan term in months
+        TermMonths: int
+        /// The monthly payment amount (if known)
+        MonthlyPayment: int64<Cent> option
+        /// The equipment being financed
+        EquipmentDescription: string
+        /// The cost of the equipment
+        EquipmentCost: int64<Cent>
+        /// Down payment made on the equipment
+        DownPayment: int64<Cent>
+        /// Residual value at end of loan term
+        ResidualValue: int64<Cent>
+    }
+
+    /// Loan payment calculation result
+    type PaymentCalculation = {
+        /// The calculated monthly payment
+        MonthlyPayment: int64<Cent>
+        /// Total payments over the loan term
+        TotalPayments: int64<Cent>
+        /// Total interest paid over the loan term
+        TotalInterest: int64<Cent>
+        /// The annual percentage rate
+        Apr: Percent
+    }
+
+    /// Loan amortization schedule item
+    type AmortizationItem = {
+        /// Payment number (1-based)
+        PaymentNumber: int
+        /// Payment due date
+        PaymentDate: DateDay.Date
+        /// The payment amount
+        PaymentAmount: int64<Cent>
+        /// Principal portion of payment
+        PrincipalPayment: int64<Cent>
+        /// Interest portion of payment
+        InterestPayment: int64<Cent>
+        /// Remaining principal balance
+        RemainingBalance: int64<Cent>
+    }
+
+    /// Calculate monthly payment for an equipment loan
+    let calculateMonthlyPayment (terms: EquipmentLoanTerms) : int64<Cent> =
+        match terms.MonthlyPayment with
+        | Some payment -> payment
+        | None ->
+            let monthlyRate = 
+                match terms.InterestRate with
+                | Interest.Rate.Zero -> 0m
+                | Interest.Rate.Annual (Percent rate) -> rate / 100m / 12m
+                | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / 12m
+            
+            if monthlyRate = 0m then
+                // No interest, just divide principal by term
+                terms.Principal / int64 terms.TermMonths
+            else
+                let loanAmount = terms.Principal - terms.ResidualValue
+                let numerator = decimal loanAmount * monthlyRate * pow (1m + monthlyRate) (decimal terms.TermMonths)
+                let denominator = pow (1m + monthlyRate) (decimal terms.TermMonths) - 1m
+                let payment = numerator / denominator
+                payment * 1m<Cent> |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+
+    /// Calculate payment details for an equipment loan
+    let calculatePaymentDetails (terms: EquipmentLoanTerms) : PaymentCalculation =
+        let monthlyPayment = calculateMonthlyPayment terms
+        let totalPayments = monthlyPayment * int64 terms.TermMonths + terms.ResidualValue
+        let totalInterest = totalPayments - terms.Principal
+        
+        // Simplified APR calculation (actual APR would require iterative calculation)
+        let annualRate = 
+            match terms.InterestRate with
+            | Interest.Rate.Zero -> Percent 0m
+            | Interest.Rate.Annual percent -> percent
+            | Interest.Rate.Daily (Percent rate) -> Percent (rate * 365m)
+        
+        {
+            MonthlyPayment = monthlyPayment
+            TotalPayments = totalPayments
+            TotalInterest = totalInterest
+            Apr = annualRate
+        }
+
+    /// Generate loan amortization schedule
+    let generateAmortizationSchedule (terms: EquipmentLoanTerms) (startDate: DateDay.Date) : AmortizationItem array =
+        let monthlyPayment = calculateMonthlyPayment terms
+        let monthlyRate = 
+            match terms.InterestRate with
+            | Interest.Rate.Zero -> 0m
+            | Interest.Rate.Annual (Percent rate) -> rate / 100m / 12m
+            | Interest.Rate.Daily (Percent rate) -> rate / 100m * 365m / 12m
+        
+        let rec generateSchedule paymentNum currentDate balance acc =
+            if paymentNum > terms.TermMonths then
+                acc |> List.rev |> Array.ofList
+            else
+                let interestPayment = 
+                    decimal balance * monthlyRate * 1m<Cent>
+                    |> Cent.fromDecimalCent (RoundWith MidpointRounding.AwayFromZero)
+                
+                let principalPayment = 
+                    if paymentNum = terms.TermMonths then
+                        // Final payment: pay remaining balance minus residual
+                        balance - terms.ResidualValue
+                    else
+                        monthlyPayment - interestPayment
+                
+                let newBalance = balance - principalPayment
+                let paymentDate = startDate.AddMonths(paymentNum)
+                
+                let item = {
+                    PaymentNumber = paymentNum
+                    PaymentDate = paymentDate
+                    PaymentAmount = if paymentNum = terms.TermMonths then principalPayment + interestPayment else monthlyPayment
+                    PrincipalPayment = principalPayment
+                    InterestPayment = interestPayment
+                    RemainingBalance = newBalance
+                }
+                
+                generateSchedule (paymentNum + 1) paymentDate newBalance (item :: acc)
+        
+        generateSchedule 1 startDate terms.Principal []
+
+    /// Analyze equipment loan with depreciation considerations
+    type LoanAnalysis = {
+        /// Loan payment calculation
+        PaymentDetails: PaymentCalculation
+        /// Depreciation schedule for the equipment
+        DepreciationSchedule: Types.DepreciationYear list
+        /// Loan amortization schedule
+        AmortizationSchedule: AmortizationItem array
+        /// Net present value analysis would go here in a full implementation
+        NetPresentValue: int64<Cent> option
+    }
+
+    /// Perform comprehensive analysis of an equipment loan
+    let analyzeLoan (terms: EquipmentLoanTerms) (startDate: DateDay.Date) : LoanAnalysis =
+        let paymentDetails = calculatePaymentDetails terms
+        let amortizationSchedule = generateAmortizationSchedule terms startDate
+        
+        // Create MACRS asset for depreciation analysis
+        let macrsAsset = {
+            Types.CostBasis = terms.EquipmentCost
+            Types.PlacedInServiceDate = startDate
+            Types.PropertyClass = Calculations.classifyAsset terms.EquipmentDescription
+            Types.Convention = Types.Convention.HalfYear
+        }
+        
+        let depreciationSchedule = Calculations.generateSchedule macrsAsset
+        
+        {
+            PaymentDetails = paymentDetails
+            DepreciationSchedule = depreciationSchedule
+            AmortizationSchedule = amortizationSchedule
+            NetPresentValue = None // Would implement NPV calculation in full version
+        }

--- a/src/FSharp.Finance.Personal.fsproj
+++ b/src/FSharp.Finance.Personal.fsproj
@@ -52,7 +52,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="9.0.201" />
+    <PackageReference Update="FSharp.Core" Version="8.0.300" />
   </ItemGroup>
   <PropertyGroup>
     <RepositoryUrl>https://github.com/simontreanor/FSharp.Finance.Personal</RepositoryUrl>

--- a/src/FSharp.Finance.Personal.fsproj
+++ b/src/FSharp.Finance.Personal.fsproj
@@ -24,6 +24,11 @@
     <Compile Include="Amortisation.fs" />
     <Compile Include="Quotes.fs" />
     <Compile Include="Refinancing.fs" />
+    <Compile Include="EquipmentFinance/Depreciation/DepreciationCommon.fs" />
+    <Compile Include="EquipmentFinance/Depreciation/US_MACRS.fs" />
+    <Compile Include="EquipmentFinance/Depreciation/UK_CapitalAllowances.fs" />
+    <Compile Include="EquipmentFinance/Loan.fs" />
+    <Compile Include="EquipmentFinance/Lease.fs" />
     <None Include="icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/FSharp.Finance.Personal.fsproj
+++ b/src/FSharp.Finance.Personal.fsproj
@@ -57,7 +57,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.300" />
+    <PackageReference Update="FSharp.Core" Version="9.0.201" />
   </ItemGroup>
   <PropertyGroup>
     <RepositoryUrl>https://github.com/simontreanor/FSharp.Finance.Personal</RepositoryUrl>

--- a/src/Fee.fs
+++ b/src/Fee.fs
@@ -14,13 +14,13 @@ module Fee =
     [<Struct; StructuredFormatDisplay("{Html}")>]
     type FeeType =
         /// a fee enabling the provision of a financial product
-        | FacilitationFee of Amount
+        | FacilitationFee of FacilitationAmount: Amount
         /// a fee charged by a Credit Access Business (CAB) or Credit Services Organisation (CSO) assisting access to third-party financial products
-        | CabOrCsoFee of Amount
+        | CabOrCsoFee of CabOrCsoAmount: Amount
         /// a fee charged by a bank or building society for arranging a mortgage
-        | MortageFee of Amount
+        | MortageFee of MortgageAmount: Amount
         /// any other type of product fee
-        | CustomFee of string * Amount
+        | CustomFee of CustomDescription: string * CustomAmount: Amount
 
         /// HTML formatting to display the fee type in a readable format
         member ft.Html =

--- a/src/Fee.fs
+++ b/src/Fee.fs
@@ -18,7 +18,7 @@ module Fee =
         /// a fee charged by a Credit Access Business (CAB) or Credit Services Organisation (CSO) assisting access to third-party financial products
         | CabOrCsoFee of CabOrCsoAmount: Amount
         /// a fee charged by a bank or building society for arranging a mortgage
-        | MortageFee of MortgageAmount: Amount
+        | MortageFee of MortageAmount: Amount
         /// any other type of product fee
         | CustomFee of CustomDescription: string * CustomAmount: Amount
 

--- a/src/Interest.fs
+++ b/src/Interest.fs
@@ -14,9 +14,9 @@ module Interest =
         /// a zero rate
         | Zero
         /// the annual interest rate, or the daily interest rate multiplied by 365
-        | Annual of Percent
+        | Annual of AnnualPercent: Percent
         /// the daily interest rate, or the annual interest rate divided by 365
-        | Daily of Percent
+        | Daily of DailyPercent: Percent
 
         /// HTML formatting to display the rate in a readable format
         member r.Html =

--- a/src/Scheduling.fs
+++ b/src/Scheduling.fs
@@ -95,15 +95,15 @@ module Scheduling =
     [<RequireQualifiedAccess; Struct; StructuredFormatDisplay("{Html}")>]
     type ActualPaymentStatus =
         /// a write-off payment has been applied
-        | WriteOff of int64<Cent>
+        | WriteOff of WriteOffAmount: int64<Cent>
         /// the payment has been initiated but is not yet confirmed
-        | Pending of int64<Cent>
+        | Pending of PendingAmount: int64<Cent>
         /// the payment had been initiated but was not confirmed within the timeout
-        | TimedOut of int64<Cent>
+        | TimedOut of TimedOutAmount: int64<Cent>
         /// the payment has been confirmed
-        | Confirmed of int64<Cent>
+        | Confirmed of ConfirmedAmount: int64<Cent>
         /// the payment has been failed, with optional charges (e.g. due to insufficient-funds penalties)
-        | Failed of int64<Cent> * Charge.ChargeType voption
+        | Failed of FailedAmount: int64<Cent> * FailedChargeType: Charge.ChargeType voption
 
         /// HTML formatting to display the actual payment status in a readable format
         member aps.Html =
@@ -333,9 +333,9 @@ module Scheduling =
         /// no minimum payment
         | NoMinimumPayment
         /// add the payment due to the next payment or close the balance if the final payment
-        | DeferOrWriteOff of int64<Cent>
+        | DeferOrWriteOff of DeferOrWriteOffAmount: int64<Cent>
         /// take the minimum payment regardless
-        | ApplyMinimumPayment of int64<Cent>
+        | ApplyMinimumPayment of ApplyMinimumAmount: int64<Cent>
 
         /// HTML formatting to display the minimum payment in a readable format
         member mp.Html =

--- a/tests/DepreciationCommonTests.fs
+++ b/tests/DepreciationCommonTests.fs
@@ -99,8 +99,12 @@ module DepreciationCommonTests =
         // Never below salvage
         schedule |> Array.iter (fun p -> p.BookValue |> should be (greaterThanOrEqualTo salvage))
 
-        // Methods should be only "DB"
-        schedule |> Array.iter (fun p -> p.Method |> should equal "DB")
+        // Rate-based periods are labelled "DB"; the final period is a plug to land exactly
+        // on salvage and is labelled distinctly
+        schedule
+        |> Array.take (schedule.Length - 1)
+        |> Array.iter (fun p -> p.Method |> should equal "DB")
+        (schedule |> Array.last).Method |> should equal "DB (final adjustment)"
 
         // Sum depreciation = cost - salvage
         let totalDep = schedule |> Array.sumBy (fun p -> p.Depreciation)

--- a/tests/DepreciationCommonTests.fs
+++ b/tests/DepreciationCommonTests.fs
@@ -8,23 +8,6 @@ open FSharp.Finance.Personal.EquipmentFinance.Depreciation.DepreciationCommon
 module DepreciationCommonTests =
 
     [<Fact>]
-    let ``Rounding currency works correctly`` () =
-        Rounding.roundCurrency 12.345m |> should equal 12.35m
-        Rounding.roundCurrency 12.344m |> should equal 12.34m
-        Rounding.roundCurrency 12.346m |> should equal 12.35m
-
-    [<Fact>]
-    let ``Rounding to places works correctly`` () =
-        Rounding.roundToPlaces 3 12.3456m |> should equal 12.346m
-        Rounding.roundToPlaces 1 12.34m |> should equal 12.3m
-        Rounding.roundToPlaces 0 12.7m |> should equal 13m
-
-    [<Fact>]
-    let ``Rounding percentage works correctly`` () =
-        Rounding.roundPercentage 0.123456m |> should equal 0.1235m
-        Rounding.roundPercentage 0.12m |> should equal 0.12m
-
-    [<Fact>]
     let ``Validate positive amount accepts positive values`` () =
         Validation.validatePositiveAmount 100L<FSharp.Finance.Personal.Calculation.Cent> "test" // Should not throw
 

--- a/tests/DepreciationCommonTests.fs
+++ b/tests/DepreciationCommonTests.fs
@@ -3,18 +3,19 @@ namespace FSharp.Finance.Personal.Tests
 open Xunit
 open FsUnit.Xunit
 
+open FSharp.Finance.Personal.Calculation
 open FSharp.Finance.Personal.EquipmentFinance.Depreciation.DepreciationCommon
 
 module DepreciationCommonTests =
 
     [<Fact>]
     let ``Validate positive amount accepts positive values`` () =
-        Validation.validatePositiveAmount 100L<FSharp.Finance.Personal.Calculation.Cent> "test" // Should not throw
+        Validation.validatePositiveAmount 100L<Cent> "test" // Should not throw
 
     [<Fact>]
     let ``Validate positive amount rejects zero and negative`` () =
-        (fun () -> Validation.validatePositiveAmount 0L<FSharp.Finance.Personal.Calculation.Cent> "test") |> should throw typeof<System.Exception>
-        (fun () -> Validation.validatePositiveAmount -10L<FSharp.Finance.Personal.Calculation.Cent> "test") |> should throw typeof<System.Exception>
+        (fun () -> Validation.validatePositiveAmount 0L<Cent> "test") |> should throw typeof<System.Exception>
+        (fun () -> Validation.validatePositiveAmount -10L<Cent> "test") |> should throw typeof<System.Exception>
 
     [<Fact>]
     let ``Validate percentage accepts valid range`` () =
@@ -29,30 +30,133 @@ module DepreciationCommonTests =
 
     [<Fact>]
     let ``Calculate remaining value works`` () =
-        Calculations.calculateRemainingValue 10000L<FSharp.Finance.Personal.Calculation.Cent> 3000L<FSharp.Finance.Personal.Calculation.Cent> |> should equal 7000L<FSharp.Finance.Personal.Calculation.Cent>
-        Calculations.calculateRemainingValue 5000L<FSharp.Finance.Personal.Calculation.Cent> 5000L<FSharp.Finance.Personal.Calculation.Cent> |> should equal 0L<FSharp.Finance.Personal.Calculation.Cent>
+        Calculations.calculateRemainingValue 10000L<Cent> 3000L<Cent> |> should equal 7000L<Cent>
+        Calculations.calculateRemainingValue 5000L<Cent> 5000L<Cent> |> should equal 0L<Cent>
 
     [<Fact>]
     let ``Apply rate works correctly`` () =
-        Calculations.applyRate 1000L<FSharp.Finance.Personal.Calculation.Cent> 0.18m |> should equal 180L<FSharp.Finance.Personal.Calculation.Cent>
-        Calculations.applyRate 5000L<FSharp.Finance.Personal.Calculation.Cent> 0.06m |> should equal 300L<FSharp.Finance.Personal.Calculation.Cent>
+        Calculations.applyRate 1000L<Cent> 0.18m |> should equal 180L<Cent>
+        Calculations.applyRate 5000L<Cent> 0.06m |> should equal 300L<Cent>
 
     [<Fact>]
     let ``Cap depreciation at cost works`` () =
-        let originalCost = 10000L<FSharp.Finance.Personal.Calculation.Cent>
-        let cumulative = 5000L<FSharp.Finance.Personal.Calculation.Cent>
+        let originalCost = 10000L<Cent>
+        let cumulative = 5000L<Cent>
         
         // Normal case - no capping needed
-        Calculations.capDepreciationAtCost originalCost 1000L<FSharp.Finance.Personal.Calculation.Cent> cumulative |> should equal 1000L<FSharp.Finance.Personal.Calculation.Cent>
+        Calculations.capDepreciationAtCost originalCost 1000L<Cent> cumulative |> should equal 1000L<Cent>
         
         // Capping needed - proposed exceeds remaining
-        Calculations.capDepreciationAtCost originalCost 6000L<FSharp.Finance.Personal.Calculation.Cent> cumulative |> should equal 5000L<FSharp.Finance.Personal.Calculation.Cent>
+        Calculations.capDepreciationAtCost originalCost 6000L<Cent> cumulative |> should equal 5000L<Cent>
         
         // Edge case - exactly at limit
-        Calculations.capDepreciationAtCost originalCost 5000L<FSharp.Finance.Personal.Calculation.Cent> cumulative |> should equal 5000L<FSharp.Finance.Personal.Calculation.Cent>
+        Calculations.capDepreciationAtCost originalCost 5000L<Cent> cumulative |> should equal 5000L<Cent>
 
     [<Fact>]
     let ``Educational disclaimer is not empty`` () =
         Disclaimers.EducationalDisclaimer |> should not' (be EmptyString)
         Disclaimers.UKSpecificDisclaimer |> should not' (be EmptyString)
         Disclaimers.USSpecificDisclaimer |> should not' (be EmptyString)
+
+    [<Fact>]
+    let ``Straight-line depreciation sums to cost minus salvage`` () =
+        let cost    = 10000_00L<Cent>   // 10,000.00
+        let salvage =  1000_00L<Cent>   // 1,000.00
+        let life = 5
+
+        let schedule = Calculations.straightLine cost salvage life
+        schedule.Length |> should equal life
+
+        let totalDep =
+            schedule |> Array.sumBy (fun p -> p.Depreciation)
+
+        totalDep |> should equal (cost - salvage)
+
+        // Final book value equals salvage
+        let last = schedule |> Array.last
+        last.BookValue |> should equal salvage
+        // Monotonic decline
+        schedule |> Array.pairwise |> Array.iter (fun (a,b) ->
+            b.BookValue |> should be (lessThanOrEqualTo a.BookValue))
+
+        // All methods flagged SL
+        schedule |> Array.iter (fun p -> p.Method |> should equal "SL")
+
+
+    [<Fact>]
+    let ``Declining balance without switch reaches salvage and never goes below`` () =
+        let cost    = 20000_00L<Cent>   // 20,000.00
+        let salvage =  2000_00L<Cent>   // 2,000.00
+        let life = 8
+        let rateFactor = 2.0m
+
+        let schedule = Calculations.decliningBalance cost salvage life rateFactor false
+        schedule.Length |> should equal life
+
+        let final = schedule |> Array.last
+        final.BookValue |> should equal salvage
+
+        // Never below salvage
+        schedule |> Array.iter (fun p -> p.BookValue |> should be (greaterThanOrEqualTo salvage))
+
+        // Methods should be only "DB"
+        schedule |> Array.iter (fun p -> p.Method |> should equal "DB")
+
+        // Sum depreciation = cost - salvage
+        let totalDep = schedule |> Array.sumBy (fun p -> p.Depreciation)
+        totalDep |> should equal (cost - salvage)
+
+
+    [<Fact>]
+    let ``Declining balance switches to straight-line for optimal write-off`` () =
+        let cost    = 15000_00L<Cent>
+        let salvage =  500_00L<Cent>
+        let life = 6
+        let rateFactor = 2.0m
+
+        let schedule = Calculations.decliningBalance cost salvage life rateFactor true
+        schedule.Length |> should equal life
+
+        // Ensure at least one period uses switch method
+        schedule |> Array.exists (fun p -> p.Method = "DB->SL") |> should equal true
+
+        let final = Array.last schedule
+        final.BookValue |> should equal salvage
+
+        // Sum depreciation = cost - salvage
+        let totalDep = schedule |> Array.sumBy (fun p -> p.Depreciation)
+        totalDep |> should equal (cost - salvage)
+
+        // Monotonic decline
+        schedule |> Array.pairwise |> Array.iter (fun (a,b) ->
+            b.BookValue |> should be (lessThanOrEqualTo a.BookValue))
+
+    [<Fact>]
+    let ``Straight-line final adjustment keeps salvage exact despite rounding`` () =
+        // Choose numbers that cause repeating decimals
+        let cost    = 9999_99L<Cent>
+        let salvage =   123_45L<Cent>
+        let life = 7
+
+        let schedule = Calculations.straightLine cost salvage life
+        let final = schedule |> Array.last
+        final.BookValue |> should equal salvage
+
+        // Total depreciation matches cost - salvage
+        schedule |> Array.sumBy (fun p -> p.Depreciation)
+        |> should equal (cost - salvage)
+
+    [<Fact>]
+    let ``Declining balance never depreciates below salvage mid-schedule`` () =
+        let cost    = 8000_00L<Cent>
+        let salvage = 1000_00L<Cent>
+        let life = 10
+        let rateFactor = 2.0m
+
+        let schedule = Calculations.decliningBalance cost salvage life rateFactor true
+
+        schedule
+        |> Array.take (schedule.Length - 1)
+        |> Array.iter (fun p -> p.BookValue |> should be (greaterThan salvage))
+
+        (Array.last schedule).BookValue |> should equal salvage

--- a/tests/DepreciationCommonTests.fs
+++ b/tests/DepreciationCommonTests.fs
@@ -1,0 +1,75 @@
+namespace FSharp.Finance.Personal.Tests
+
+open Xunit
+open FsUnit.Xunit
+
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.DepreciationCommon
+
+module DepreciationCommonTests =
+
+    [<Fact>]
+    let ``Rounding currency works correctly`` () =
+        Rounding.roundCurrency 12.345m |> should equal 12.35m
+        Rounding.roundCurrency 12.344m |> should equal 12.34m
+        Rounding.roundCurrency 12.346m |> should equal 12.35m
+
+    [<Fact>]
+    let ``Rounding to places works correctly`` () =
+        Rounding.roundToPlaces 3 12.3456m |> should equal 12.346m
+        Rounding.roundToPlaces 1 12.34m |> should equal 12.3m
+        Rounding.roundToPlaces 0 12.7m |> should equal 13m
+
+    [<Fact>]
+    let ``Rounding percentage works correctly`` () =
+        Rounding.roundPercentage 0.123456m |> should equal 0.1235m
+        Rounding.roundPercentage 0.12m |> should equal 0.12m
+
+    [<Fact>]
+    let ``Validate positive amount accepts positive values`` () =
+        Validation.validatePositiveAmount 100L<FSharp.Finance.Personal.Calculation.Cent> "test" // Should not throw
+
+    [<Fact>]
+    let ``Validate positive amount rejects zero and negative`` () =
+        (fun () -> Validation.validatePositiveAmount 0L<FSharp.Finance.Personal.Calculation.Cent> "test") |> should throw typeof<System.Exception>
+        (fun () -> Validation.validatePositiveAmount -10L<FSharp.Finance.Personal.Calculation.Cent> "test") |> should throw typeof<System.Exception>
+
+    [<Fact>]
+    let ``Validate percentage accepts valid range`` () =
+        Validation.validatePercentage 0m "test" // Should not throw
+        Validation.validatePercentage 0.5m "test" // Should not throw
+        Validation.validatePercentage 1m "test" // Should not throw
+
+    [<Fact>]
+    let ``Validate percentage rejects invalid range`` () =
+        (fun () -> Validation.validatePercentage -0.1m "test") |> should throw typeof<System.Exception>
+        (fun () -> Validation.validatePercentage 1.1m "test") |> should throw typeof<System.Exception>
+
+    [<Fact>]
+    let ``Calculate remaining value works`` () =
+        Calculations.calculateRemainingValue 10000L<FSharp.Finance.Personal.Calculation.Cent> 3000L<FSharp.Finance.Personal.Calculation.Cent> |> should equal 7000L<FSharp.Finance.Personal.Calculation.Cent>
+        Calculations.calculateRemainingValue 5000L<FSharp.Finance.Personal.Calculation.Cent> 5000L<FSharp.Finance.Personal.Calculation.Cent> |> should equal 0L<FSharp.Finance.Personal.Calculation.Cent>
+
+    [<Fact>]
+    let ``Apply rate works correctly`` () =
+        Calculations.applyRate 1000L<FSharp.Finance.Personal.Calculation.Cent> 0.18m |> should equal 180L<FSharp.Finance.Personal.Calculation.Cent>
+        Calculations.applyRate 5000L<FSharp.Finance.Personal.Calculation.Cent> 0.06m |> should equal 300L<FSharp.Finance.Personal.Calculation.Cent>
+
+    [<Fact>]
+    let ``Cap depreciation at cost works`` () =
+        let originalCost = 10000L<FSharp.Finance.Personal.Calculation.Cent>
+        let cumulative = 5000L<FSharp.Finance.Personal.Calculation.Cent>
+        
+        // Normal case - no capping needed
+        Calculations.capDepreciationAtCost originalCost 1000L<FSharp.Finance.Personal.Calculation.Cent> cumulative |> should equal 1000L<FSharp.Finance.Personal.Calculation.Cent>
+        
+        // Capping needed - proposed exceeds remaining
+        Calculations.capDepreciationAtCost originalCost 6000L<FSharp.Finance.Personal.Calculation.Cent> cumulative |> should equal 5000L<FSharp.Finance.Personal.Calculation.Cent>
+        
+        // Edge case - exactly at limit
+        Calculations.capDepreciationAtCost originalCost 5000L<FSharp.Finance.Personal.Calculation.Cent> cumulative |> should equal 5000L<FSharp.Finance.Personal.Calculation.Cent>
+
+    [<Fact>]
+    let ``Educational disclaimer is not empty`` () =
+        Disclaimers.EducationalDisclaimer |> should not' (be EmptyString)
+        Disclaimers.UKSpecificDisclaimer |> should not' (be EmptyString)
+        Disclaimers.USSpecificDisclaimer |> should not' (be EmptyString)

--- a/tests/EquipmentLeaseTests.fs
+++ b/tests/EquipmentLeaseTests.fs
@@ -2,8 +2,9 @@ namespace FSharp.Finance.Personal.Tests
 
 open Xunit
 open FsUnit.Xunit
-
+open FSharp.Finance.Personal.Calculation
 open FSharp.Finance.Personal.EquipmentFinance
+open FSharp.Finance.Personal.EquipmentFinance.Lease
 
 module EquipmentLeaseTests =
 
@@ -18,73 +19,93 @@ module EquipmentLeaseTests =
     let ``Lease payment calculation works for zero interest`` () =
         let terms = {
             EquipmentDescription = "Test equipment"
-            FairMarketValue = 120000L<FSharp.Finance.Personal.Calculation.Cent> // $1,200
+            FairMarketValue = 1200_00L<Cent> // $1,200
             TermMonths = 12
             LeaseType = Lease.LeaseType.OperatingLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            UpfrontPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 20000L<FSharp.Finance.Personal.Calculation.Cent> // $200
+            LeasePayment = 0L<Cent>
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 200_00L<Cent> // $200
             PurchaseOption = None
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Zero
         }
         
         let payment = Lease.calculateLeasePayment terms
         // ($1200 - $200) / 12 = $83.33
-        payment |> should equal 8333L<FSharp.Finance.Personal.Calculation.Cent>
+        payment |> should equal 83_33L<Cent>
 
-    [<Fact>]
+    [<Fact>] // this test still fails
     let ``Lease payment calculation works with interest`` () =
         let terms = {
             EquipmentDescription = "Manufacturing equipment"
-            FairMarketValue = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            FairMarketValue = 10000_00L<Cent>
             TermMonths = 36
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            UpfrontPayment = 100000L<FSharp.Finance.Personal.Calculation.Cent> // $1,000
-            ResidualValue = 200000L<FSharp.Finance.Personal.Calculation.Cent> // $2,000
-            PurchaseOption = Some 200000L<FSharp.Finance.Personal.Calculation.Cent>
+            LeasePayment = 0L<Cent>
+            UpfrontPayment = 1000_00L<Cent>
+            ResidualValue = 2000_00L<Cent>
+            PurchaseOption = Some 2000_00L<Cent>
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 5.0m)
         }
-        
+
         let payment = Lease.calculateLeasePayment terms
-        // Payment should be greater than simple division due to interest
-        payment |> should be (greaterThan 22222L<FSharp.Finance.Personal.Calculation.Cent>) // Simple calculation would be less
+
+        // Correct zero-interest baseline (uses upfront + residual)
+        let zeroInterestBaseline =
+            let initial = (terms.FairMarketValue - terms.UpfrontPayment - terms.ResidualValue) |> Cent.toDecimal
+            initial / (decimal (terms.TermMonths * terms.PaymentFrequency.PaymentsPerYear / 12)) 
+            |> Cent.fromDecimal
+
+        payment |> should be (greaterThan zeroInterestBaseline)
+
+        // Expected theoretical payment (recalculate in test for robustness)
+        let r = 0.05m / 12m
+        let n = 36
+        let principalNet = Cent.toDecimal terms.FairMarketValue - Cent.toDecimal terms.UpfrontPayment
+        let residual = Cent.toDecimal terms.ResidualValue
+        let growth = System.Math.Pow(float (1m + r), float n) |> decimal
+        let pvResidual = residual / growth
+        let baseAmt = principalNet - pvResidual
+        let annuityFactor = (1m - 1m / growth) / r
+        let expectedDec = baseAmt / annuityFactor
+        let expectedCents = Cent.fromDecimal expectedDec
+        // Allow 1 cent tolerance for rounding differences
+        abs (payment - expectedCents) |> should be (lessThanOrEqualTo 1L<Cent>)
 
     [<Fact>]
     let ``Lease details calculation includes total cost`` () =
         let terms = {
             EquipmentDescription = "Office equipment"
-            FairMarketValue = 500000L<FSharp.Finance.Personal.Calculation.Cent> // $5,000
+            FairMarketValue = 500000L<Cent> // $5,000
             TermMonths = 24
             LeaseType = Lease.LeaseType.OperatingLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 20000L<FSharp.Finance.Personal.Calculation.Cent> // $200/month
-            UpfrontPayment = 50000L<FSharp.Finance.Personal.Calculation.Cent> // $500
-            ResidualValue = 100000L<FSharp.Finance.Personal.Calculation.Cent> // $1,000
-            PurchaseOption = Some 100000L<FSharp.Finance.Personal.Calculation.Cent>
+            LeasePayment = 200_00L<Cent> // $200/month
+            UpfrontPayment = 500_00L<Cent> // $500
+            ResidualValue = 1000_00L<Cent> // $1,000
+            PurchaseOption = Some 1000_00L<Cent>
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
         }
         
         let details = Lease.calculateLeaseDetails terms
         
-        details.LeasePayment |> should equal 20000L<FSharp.Finance.Personal.Calculation.Cent>
-        details.TotalPayments |> should equal 530000L<FSharp.Finance.Personal.Calculation.Cent> // $200*24 + $500
-        details.TotalCost |> should equal 630000L<FSharp.Finance.Personal.Calculation.Cent> // Total payments + purchase option
-        details.PresentValue |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        details.LeasePayment |> should equal 20000L<Cent>
+        details.TotalPayments |> should equal 530000L<Cent> // $200*24 + $500
+        details.TotalCost |> should equal 630000L<Cent> // Total payments + purchase option
+        details.PresentValue |> should be (greaterThan 0L<Cent>)
 
     [<Fact>]
     let ``Lease schedule has correct length`` () =
         let terms = {
             EquipmentDescription = "Computer"
-            FairMarketValue = 300000L<FSharp.Finance.Personal.Calculation.Cent> // $3,000
+            FairMarketValue = 3000_00L<Cent> // $3,000
             TermMonths = 12
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 25000L<FSharp.Finance.Personal.Calculation.Cent> // $250/month
-            UpfrontPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 50000L<FSharp.Finance.Personal.Calculation.Cent> // $500
+            LeasePayment = 250_00L<Cent> // $250/month
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 500_00L<Cent> // $500
             PurchaseOption = None
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 3.0m)
         }
@@ -102,19 +123,19 @@ module EquipmentLeaseTests =
         
         // All payments should have the same amount for operating lease
         schedule |> Array.iter (fun item -> 
-            item.PaymentAmount |> should equal 25000L<FSharp.Finance.Personal.Calculation.Cent>)
+            item.PaymentAmount |> should equal 250_00L<Cent>)
 
     [<Fact>]
     let ``Operating lease does not split principal and interest`` () =
         let terms = {
             EquipmentDescription = "Equipment"
-            FairMarketValue = 600000L<FSharp.Finance.Personal.Calculation.Cent> // $6,000
+            FairMarketValue = 6000_00L<Cent> // $6,000
             TermMonths = 24
             LeaseType = Lease.LeaseType.OperatingLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 25000L<FSharp.Finance.Personal.Calculation.Cent> // $250/month
-            UpfrontPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 100000L<FSharp.Finance.Personal.Calculation.Cent>
+            LeasePayment = 250_00L<Cent> // $250/month
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
             PurchaseOption = None
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
         }
@@ -124,20 +145,20 @@ module EquipmentLeaseTests =
         
         // Operating leases should not split principal/interest
         schedule |> Array.iter (fun item -> 
-            item.PrincipalPortion |> should equal 0L<FSharp.Finance.Personal.Calculation.Cent>
-            item.InterestPortion |> should equal 0L<FSharp.Finance.Personal.Calculation.Cent>)
+            item.PrincipalPortion |> should equal 0L<Cent>
+            item.InterestPortion |> should equal 0L<Cent>)
 
     [<Fact>]
     let ``Finance lease splits principal and interest`` () =
         let terms = {
             EquipmentDescription = "Equipment"
-            FairMarketValue = 600000L<FSharp.Finance.Personal.Calculation.Cent> // $6,000
+            FairMarketValue = 6000_00L<Cent> // $6,000
             TermMonths = 24
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 25000L<FSharp.Finance.Personal.Calculation.Cent> // $250/month
-            UpfrontPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 100000L<FSharp.Finance.Personal.Calculation.Cent>
+            LeasePayment = 250_00L<Cent> // $250/month
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
             PurchaseOption = None
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
         }
@@ -147,8 +168,8 @@ module EquipmentLeaseTests =
         
         // Finance leases should split principal and interest
         let firstPayment = schedule.[0]
-        firstPayment.PrincipalPortion |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
-        firstPayment.InterestPortion |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        firstPayment.PrincipalPortion |> should be (greaterThan 0L<Cent>)
+        firstPayment.InterestPortion |> should be (greaterThan 0L<Cent>)
         
         // Principal + interest should equal payment amount
         (firstPayment.PrincipalPortion + firstPayment.InterestPortion) |> should equal firstPayment.PaymentAmount
@@ -157,20 +178,20 @@ module EquipmentLeaseTests =
     let ``Lease vs buy analysis includes depreciation schedule`` () =
         let terms = {
             EquipmentDescription = "Manufacturing equipment"
-            FairMarketValue = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            FairMarketValue = 10000_00L<Cent> // $10,000
             TermMonths = 36
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 30000L<FSharp.Finance.Personal.Calculation.Cent> // $300/month
-            UpfrontPayment = 100000L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 200000L<FSharp.Finance.Personal.Calculation.Cent>
-            PurchaseOption = Some 200000L<FSharp.Finance.Personal.Calculation.Cent>
+            LeasePayment = 300_00L<Cent> // $300/month
+            UpfrontPayment = 1000_00L<Cent>
+            ResidualValue = 2000_00L<Cent>
+            PurchaseOption = Some 2000_00L<Cent>
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 5.0m)
         }
         
         let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
         let analysis = Lease.analyzeLeaseVsBuy terms startDate
         
-        analysis.LeaseDetails.LeasePayment |> should equal 30000L<FSharp.Finance.Personal.Calculation.Cent>
+        analysis.LeaseDetails.LeasePayment |> should equal 300_00L<Cent>
         analysis.PurchaseDepreciation |> should not' (be Empty)
         analysis.LeaseSchedule.Length |> should equal 36

--- a/tests/EquipmentLeaseTests.fs
+++ b/tests/EquipmentLeaseTests.fs
@@ -34,7 +34,7 @@ module EquipmentLeaseTests =
         // ($1200 - $200) / 12 = $83.33
         payment |> should equal 83_33L<Cent>
 
-    [<Fact>] // this test still fails
+    [<Fact>]
     let ``Lease payment calculation works with interest`` () =
         let terms = {
             EquipmentDescription = "Manufacturing equipment"
@@ -120,10 +120,9 @@ module EquipmentLeaseTests =
         
         // Last payment should have payment number equal to term
         schedule.[11].PaymentNumber |> should equal 12
-        
-        // All payments should have the same amount for operating lease
-        schedule |> Array.iter (fun item -> 
-            item.PaymentAmount |> should equal 250_00L<Cent>)
+
+        schedule.[11].RemainingLiability |> should equal 500_00L<Cent>
+        schedule.[11].PaymentAmount |> should be (lessThanOrEqualTo 250_00L<Cent>)
 
     [<Fact>]
     let ``Operating lease does not split principal and interest`` () =
@@ -175,6 +174,127 @@ module EquipmentLeaseTests =
         (firstPayment.PrincipalPortion + firstPayment.InterestPortion) |> should equal firstPayment.PaymentAmount
 
     [<Fact>]
+    let ``Finance lease schedule amortizes to residual not zero`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 6000_00L<Cent>
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 250_00L<Cent>
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 4.0m)
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Lease.generateLeaseSchedule terms startDate
+        let last = schedule |> Array.last
+
+        last.RemainingLiability |> should equal 1000_00L<Cent>
+        last.PaymentAmount |> should be (lessThanOrEqualTo 250_00L<Cent>)
+
+    [<Fact>]
+    let ``Operating lease schedule carries no liability`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 6000_00L<Cent>
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.OperatingLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 250_00L<Cent>
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 4.0m)
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Lease.generateLeaseSchedule terms startDate
+
+        schedule |> Array.iter (fun item -> item.RemainingLiability |> should equal 0L<Cent>)
+
+    [<Fact>]
+    let ``Lease details uses actual schedule totals and present value`` () =
+        let terms = {
+            EquipmentDescription = "Computer"
+            FairMarketValue = 3000_00L<Cent>
+            TermMonths = 12
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 250_00L<Cent>
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 500_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 3.0m)
+        }
+
+        let details = Lease.calculateLeaseDetails terms
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Lease.generateLeaseSchedule terms startDate
+        let scheduleTotal = schedule |> Array.sumBy (fun item -> item.PaymentAmount)
+
+        details.TotalPayments |> should equal scheduleTotal
+        details.PresentValue |> should be (lessThanOrEqualTo details.TotalPayments)
+
+    [<Fact>]
+    let ``Finance lease rejects rental below period interest`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 10000_00L<Cent>
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 1_00L<Cent>
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 12.0m)
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        (fun () -> Lease.generateLeaseSchedule terms startDate |> ignore)
+        |> should throw typeof<System.ArgumentException>
+
+    [<Fact>]
+    let ``Finance lease rejects rental that cannot reach residual by maturity`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 6000_00L<Cent>
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 50_00L<Cent>
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 4.0m)
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        (fun () -> Lease.generateLeaseSchedule terms startDate |> ignore)
+        |> should throw typeof<System.ArgumentException>
+
+    [<Fact>]
+    let ``Lease rejects upfront payment at or above fair value`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 6000_00L<Cent>
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 0L<Cent>
+            UpfrontPayment = 6000_00L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 4.0m)
+        }
+
+        (fun () -> Lease.calculateLeasePayment terms |> ignore)
+        |> should throw typeof<System.ArgumentException>
+
+    [<Fact>]
     let ``Lease vs buy analysis includes depreciation schedule`` () =
         let terms = {
             EquipmentDescription = "Manufacturing equipment"
@@ -195,3 +315,21 @@ module EquipmentLeaseTests =
         analysis.LeaseDetails.LeasePayment |> should equal 300_00L<Cent>
         analysis.PurchaseDepreciation |> should not' (be Empty)
         analysis.LeaseSchedule.Length |> should equal 36
+
+    [<Fact>]
+    let ``Lease rejects term incompatible with payment frequency`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 6000_00L<Cent>
+            TermMonths = 13
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Quarterly
+            LeasePayment = 0L<Cent>
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 4.0m)
+        }
+
+        (fun () -> Lease.calculateLeasePayment terms |> ignore)
+        |> should throw typeof<System.ArgumentException>

--- a/tests/EquipmentLeaseTests.fs
+++ b/tests/EquipmentLeaseTests.fs
@@ -1,0 +1,176 @@
+namespace FSharp.Finance.Personal.Tests
+
+open Xunit
+open FsUnit.Xunit
+
+open FSharp.Finance.Personal.EquipmentFinance
+
+module EquipmentLeaseTests =
+
+    [<Fact>]
+    let ``Payment frequency to payments per year conversion works`` () =
+        Lease.PaymentFrequency.Monthly.PaymentsPerYear |> should equal 12
+        Lease.PaymentFrequency.Quarterly.PaymentsPerYear |> should equal 4
+        Lease.PaymentFrequency.SemiAnnual.PaymentsPerYear |> should equal 2
+        Lease.PaymentFrequency.Annual.PaymentsPerYear |> should equal 1
+
+    [<Fact>]
+    let ``Lease payment calculation works for zero interest`` () =
+        let terms = {
+            EquipmentDescription = "Test equipment"
+            FairMarketValue = 120000L<FSharp.Finance.Personal.Calculation.Cent> // $1,200
+            TermMonths = 12
+            LeaseType = Lease.LeaseType.OperatingLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            UpfrontPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 20000L<FSharp.Finance.Personal.Calculation.Cent> // $200
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Zero
+        }
+        
+        let payment = Lease.calculateLeasePayment terms
+        // ($1200 - $200) / 12 = $83.33
+        payment |> should equal 8333L<FSharp.Finance.Personal.Calculation.Cent>
+
+    [<Fact>]
+    let ``Lease payment calculation works with interest`` () =
+        let terms = {
+            EquipmentDescription = "Manufacturing equipment"
+            FairMarketValue = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            TermMonths = 36
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            UpfrontPayment = 100000L<FSharp.Finance.Personal.Calculation.Cent> // $1,000
+            ResidualValue = 200000L<FSharp.Finance.Personal.Calculation.Cent> // $2,000
+            PurchaseOption = Some 200000L<FSharp.Finance.Personal.Calculation.Cent>
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 5.0m)
+        }
+        
+        let payment = Lease.calculateLeasePayment terms
+        // Payment should be greater than simple division due to interest
+        payment |> should be (greaterThan 22222L<FSharp.Finance.Personal.Calculation.Cent>) // Simple calculation would be less
+
+    [<Fact>]
+    let ``Lease details calculation includes total cost`` () =
+        let terms = {
+            EquipmentDescription = "Office equipment"
+            FairMarketValue = 500000L<FSharp.Finance.Personal.Calculation.Cent> // $5,000
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.OperatingLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 20000L<FSharp.Finance.Personal.Calculation.Cent> // $200/month
+            UpfrontPayment = 50000L<FSharp.Finance.Personal.Calculation.Cent> // $500
+            ResidualValue = 100000L<FSharp.Finance.Personal.Calculation.Cent> // $1,000
+            PurchaseOption = Some 100000L<FSharp.Finance.Personal.Calculation.Cent>
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
+        }
+        
+        let details = Lease.calculateLeaseDetails terms
+        
+        details.LeasePayment |> should equal 20000L<FSharp.Finance.Personal.Calculation.Cent>
+        details.TotalPayments |> should equal 530000L<FSharp.Finance.Personal.Calculation.Cent> // $200*24 + $500
+        details.TotalCost |> should equal 630000L<FSharp.Finance.Personal.Calculation.Cent> // Total payments + purchase option
+        details.PresentValue |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+
+    [<Fact>]
+    let ``Lease schedule has correct length`` () =
+        let terms = {
+            EquipmentDescription = "Computer"
+            FairMarketValue = 300000L<FSharp.Finance.Personal.Calculation.Cent> // $3,000
+            TermMonths = 12
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 25000L<FSharp.Finance.Personal.Calculation.Cent> // $250/month
+            UpfrontPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 50000L<FSharp.Finance.Personal.Calculation.Cent> // $500
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 3.0m)
+        }
+        
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Lease.generateLeaseSchedule terms startDate
+        
+        schedule.Length |> should equal 12
+        
+        // First payment should have payment number 1
+        schedule.[0].PaymentNumber |> should equal 1
+        
+        // Last payment should have payment number equal to term
+        schedule.[11].PaymentNumber |> should equal 12
+        
+        // All payments should have the same amount for operating lease
+        schedule |> Array.iter (fun item -> 
+            item.PaymentAmount |> should equal 25000L<FSharp.Finance.Personal.Calculation.Cent>)
+
+    [<Fact>]
+    let ``Operating lease does not split principal and interest`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 600000L<FSharp.Finance.Personal.Calculation.Cent> // $6,000
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.OperatingLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 25000L<FSharp.Finance.Personal.Calculation.Cent> // $250/month
+            UpfrontPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 100000L<FSharp.Finance.Personal.Calculation.Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
+        }
+        
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Lease.generateLeaseSchedule terms startDate
+        
+        // Operating leases should not split principal/interest
+        schedule |> Array.iter (fun item -> 
+            item.PrincipalPortion |> should equal 0L<FSharp.Finance.Personal.Calculation.Cent>
+            item.InterestPortion |> should equal 0L<FSharp.Finance.Personal.Calculation.Cent>)
+
+    [<Fact>]
+    let ``Finance lease splits principal and interest`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 600000L<FSharp.Finance.Personal.Calculation.Cent> // $6,000
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 25000L<FSharp.Finance.Personal.Calculation.Cent> // $250/month
+            UpfrontPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 100000L<FSharp.Finance.Personal.Calculation.Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
+        }
+        
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Lease.generateLeaseSchedule terms startDate
+        
+        // Finance leases should split principal and interest
+        let firstPayment = schedule.[0]
+        firstPayment.PrincipalPortion |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        firstPayment.InterestPortion |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        
+        // Principal + interest should equal payment amount
+        (firstPayment.PrincipalPortion + firstPayment.InterestPortion) |> should equal firstPayment.PaymentAmount
+
+    [<Fact>]
+    let ``Lease vs buy analysis includes depreciation schedule`` () =
+        let terms = {
+            EquipmentDescription = "Manufacturing equipment"
+            FairMarketValue = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            TermMonths = 36
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            LeasePayment = 30000L<FSharp.Finance.Personal.Calculation.Cent> // $300/month
+            UpfrontPayment = 100000L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 200000L<FSharp.Finance.Personal.Calculation.Cent>
+            PurchaseOption = Some 200000L<FSharp.Finance.Personal.Calculation.Cent>
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 5.0m)
+        }
+        
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let analysis = Lease.analyzeLeaseVsBuy terms startDate
+        
+        analysis.LeaseDetails.LeasePayment |> should equal 30000L<FSharp.Finance.Personal.Calculation.Cent>
+        analysis.PurchaseDepreciation |> should not' (be Empty)
+        analysis.LeaseSchedule.Length |> should equal 36

--- a/tests/EquipmentLeaseTests.fs
+++ b/tests/EquipmentLeaseTests.fs
@@ -23,13 +23,15 @@ module EquipmentLeaseTests =
             TermMonths = 12
             LeaseType = Lease.LeaseType.OperatingLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
             LeasePayment = 0L<Cent>
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 200_00L<Cent> // $200
             PurchaseOption = None
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Zero
         }
-        
+
         let payment = Lease.calculateLeasePayment terms
         // ($1200 - $200) / 12 = $83.33
         payment |> should equal 83_33L<Cent>
@@ -42,7 +44,9 @@ module EquipmentLeaseTests =
             TermMonths = 36
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
             LeasePayment = 0L<Cent>
+            PeriodicFee = None
             UpfrontPayment = 1000_00L<Cent>
             ResidualValue = 2000_00L<Cent>
             PurchaseOption = Some 2000_00L<Cent>
@@ -54,7 +58,7 @@ module EquipmentLeaseTests =
         // Correct zero-interest baseline (uses upfront + residual)
         let zeroInterestBaseline =
             let initial = (terms.FairMarketValue - terms.UpfrontPayment - terms.ResidualValue) |> Cent.toDecimal
-            initial / (decimal (terms.TermMonths * terms.PaymentFrequency.PaymentsPerYear / 12)) 
+            initial / (decimal (terms.TermMonths * terms.PaymentFrequency.PaymentsPerYear / 12))
             |> Cent.fromDecimal
 
         payment |> should be (greaterThan zeroInterestBaseline)
@@ -81,15 +85,17 @@ module EquipmentLeaseTests =
             TermMonths = 24
             LeaseType = Lease.LeaseType.OperatingLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
             LeasePayment = 200_00L<Cent> // $200/month
+            PeriodicFee = None
             UpfrontPayment = 500_00L<Cent> // $500
             ResidualValue = 1000_00L<Cent> // $1,000
             PurchaseOption = Some 1000_00L<Cent>
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
         }
-        
+
         let details = Lease.calculateLeaseDetails terms
-        
+
         details.LeasePayment |> should equal 20000L<Cent>
         details.TotalPayments |> should equal 530000L<Cent> // $200*24 + $500
         details.TotalCost |> should equal 630000L<Cent> // Total payments + purchase option
@@ -103,21 +109,23 @@ module EquipmentLeaseTests =
             TermMonths = 12
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 250_00L<Cent> // $250/month
+            PaymentTiming = Lease.PaymentTiming.InArrears
+            LeasePayment = 213_00L<Cent> // ~level rental consistent with the residual
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 500_00L<Cent> // $500
             PurchaseOption = None
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 3.0m)
         }
-        
+
         let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
         let schedule = Lease.generateLeaseSchedule terms startDate
-        
+
         schedule.Length |> should equal 12
-        
+
         // First payment should have payment number 1
         schedule.[0].PaymentNumber |> should equal 1
-        
+
         // Last payment should have payment number equal to term
         schedule.[11].PaymentNumber |> should equal 12
 
@@ -132,18 +140,20 @@ module EquipmentLeaseTests =
             TermMonths = 24
             LeaseType = Lease.LeaseType.OperatingLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
             LeasePayment = 250_00L<Cent> // $250/month
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 1000_00L<Cent>
             PurchaseOption = None
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
         }
-        
+
         let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
         let schedule = Lease.generateLeaseSchedule terms startDate
-        
+
         // Operating leases should not split principal/interest
-        schedule |> Array.iter (fun item -> 
+        schedule |> Array.iter (fun item ->
             item.PrincipalPortion |> should equal 0L<Cent>
             item.InterestPortion |> should equal 0L<Cent>)
 
@@ -155,21 +165,23 @@ module EquipmentLeaseTests =
             TermMonths = 24
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 250_00L<Cent> // $250/month
+            PaymentTiming = Lease.PaymentTiming.InArrears
+            LeasePayment = 220_45L<Cent> // ~level rental consistent with the residual
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 1000_00L<Cent>
             PurchaseOption = None
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
         }
-        
+
         let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
         let schedule = Lease.generateLeaseSchedule terms startDate
-        
+
         // Finance leases should split principal and interest
         let firstPayment = schedule.[0]
         firstPayment.PrincipalPortion |> should be (greaterThan 0L<Cent>)
         firstPayment.InterestPortion |> should be (greaterThan 0L<Cent>)
-        
+
         // Principal + interest should equal payment amount
         (firstPayment.PrincipalPortion + firstPayment.InterestPortion) |> should equal firstPayment.PaymentAmount
 
@@ -181,7 +193,9 @@ module EquipmentLeaseTests =
             TermMonths = 24
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 250_00L<Cent>
+            PaymentTiming = Lease.PaymentTiming.InArrears
+            LeasePayment = 220_45L<Cent> // ~level rental consistent with the residual
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 1000_00L<Cent>
             PurchaseOption = None
@@ -196,6 +210,68 @@ module EquipmentLeaseTests =
         last.PaymentAmount |> should be (lessThanOrEqualTo 250_00L<Cent>)
 
     [<Fact>]
+    let ``Finance lease charges the stated rental every period with a final plug`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 6000_00L<Cent>
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
+            LeasePayment = 220_45L<Cent>
+            PeriodicFee = None
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 4.0m)
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Lease.generateLeaseSchedule terms startDate
+
+        // every period except the last charges the stated rental verbatim - never rewritten
+        schedule
+        |> Array.take (schedule.Length - 1)
+        |> Array.iter (fun item -> item.PaymentAmount |> should equal 220_45L<Cent>)
+
+        // the final period is the plug that lands exactly on the residual
+        let last = schedule |> Array.last
+        last.RemainingLiability |> should equal 1000_00L<Cent>
+        last.PrincipalPortion + last.InterestPortion |> should equal last.PaymentAmount
+
+        // totals reflect the contractual schedule
+        let details = Lease.calculateLeaseDetails terms
+        details.TotalPayments |> should equal (schedule |> Array.sumBy (fun item -> item.PaymentAmount))
+
+    [<Fact>]
+    let ``Finance lease rejects rental too high to land on the residual`` () =
+        // audited scenario: stated rental 300.00 on a contract whose consistent level rental
+        // is ~220; the old code silently rewrote the rental to 3.33 for the last six periods
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 6000_00L<Cent>
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
+            LeasePayment = 300_00L<Cent>
+            PeriodicFee = None
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 4.0m)
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let ex =
+            Assert.Throws<System.ArgumentException>(fun () ->
+                Lease.generateLeaseSchedule terms startDate |> ignore)
+
+        // the error must be descriptive, quoting the consistent level rental
+        ex.Message |> should haveSubstring "too high"
+        ex.Message |> should haveSubstring "220"
+
+    [<Fact>]
     let ``Operating lease schedule carries no liability`` () =
         let terms = {
             EquipmentDescription = "Equipment"
@@ -203,7 +279,9 @@ module EquipmentLeaseTests =
             TermMonths = 24
             LeaseType = Lease.LeaseType.OperatingLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
             LeasePayment = 250_00L<Cent>
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 1000_00L<Cent>
             PurchaseOption = None
@@ -223,7 +301,9 @@ module EquipmentLeaseTests =
             TermMonths = 12
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 250_00L<Cent>
+            PaymentTiming = Lease.PaymentTiming.InArrears
+            LeasePayment = 213_00L<Cent> // ~level rental consistent with the residual
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 500_00L<Cent>
             PurchaseOption = None
@@ -239,6 +319,66 @@ module EquipmentLeaseTests =
         details.PresentValue |> should be (lessThanOrEqualTo details.TotalPayments)
 
     [<Fact>]
+    let ``In-advance rental is lower than in-arrears by the annuity-due factor`` () =
+        let baseTerms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 10000_00L<Cent>
+            TermMonths = 36
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
+            LeasePayment = 0L<Cent>
+            PeriodicFee = None
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 0L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 6.0m)
+        }
+
+        let arrearsPayment = Lease.calculateLeasePayment baseTerms
+        let advancePayment = Lease.calculateLeasePayment { baseTerms with PaymentTiming = Lease.PaymentTiming.InAdvance }
+
+        advancePayment |> should be (lessThan arrearsPayment)
+
+        // annuity-due factor: payment(due) = payment(ordinary) / (1 + period rate)
+        let expected = Cent.fromDecimal (Cent.toDecimal arrearsPayment / (1m + 0.06m / 12m))
+        abs (advancePayment - expected) |> should be (lessThanOrEqualTo 1L<Cent>)
+
+    [<Fact>]
+    let ``In-advance finance lease schedule lands on the residual`` () =
+        let terms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 6000_00L<Cent>
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InAdvance
+            LeasePayment = 0L<Cent>
+            PeriodicFee = None
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 4.0m)
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Lease.generateLeaseSchedule terms startDate
+
+        schedule.Length |> should equal 24
+
+        // first payment is due at the start date (in advance)
+        schedule.[0].PaymentDate |> should equal startDate
+
+        // rows are internally consistent
+        schedule |> Array.iter (fun item ->
+            item.PrincipalPortion + item.InterestPortion |> should equal item.PaymentAmount)
+
+        // the schedule lands exactly on the residual and repays principal net of residual
+        let last = schedule |> Array.last
+        last.RemainingLiability |> should equal 1000_00L<Cent>
+        schedule |> Array.sumBy (fun item -> item.PrincipalPortion) |> should equal 5000_00L<Cent>
+
+    [<Fact>]
     let ``Finance lease rejects rental below period interest`` () =
         let terms = {
             EquipmentDescription = "Equipment"
@@ -246,7 +386,9 @@ module EquipmentLeaseTests =
             TermMonths = 24
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
             LeasePayment = 1_00L<Cent>
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 1000_00L<Cent>
             PurchaseOption = None
@@ -265,7 +407,9 @@ module EquipmentLeaseTests =
             TermMonths = 24
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
             LeasePayment = 50_00L<Cent>
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 1000_00L<Cent>
             PurchaseOption = None
@@ -273,8 +417,12 @@ module EquipmentLeaseTests =
         }
 
         let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
-        (fun () -> Lease.generateLeaseSchedule terms startDate |> ignore)
-        |> should throw typeof<System.ArgumentException>
+        let ex =
+            Assert.Throws<System.ArgumentException>(fun () ->
+                Lease.generateLeaseSchedule terms startDate |> ignore)
+
+        ex.Message |> should haveSubstring "too low"
+        ex.Message |> should haveSubstring "minimum consistent level rental"
 
     [<Fact>]
     let ``Lease rejects upfront payment at or above fair value`` () =
@@ -284,7 +432,9 @@ module EquipmentLeaseTests =
             TermMonths = 24
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
             LeasePayment = 0L<Cent>
+            PeriodicFee = None
             UpfrontPayment = 6000_00L<Cent>
             ResidualValue = 1000_00L<Cent>
             PurchaseOption = None
@@ -302,19 +452,76 @@ module EquipmentLeaseTests =
             TermMonths = 36
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Monthly
-            LeasePayment = 300_00L<Cent> // $300/month
+            PaymentTiming = Lease.PaymentTiming.InArrears
+            LeasePayment = 218_14L<Cent> // ~level rental consistent with the residual
+            PeriodicFee = None
             UpfrontPayment = 1000_00L<Cent>
             ResidualValue = 2000_00L<Cent>
             PurchaseOption = Some 2000_00L<Cent>
             ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 5.0m)
         }
-        
+
         let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
-        let analysis = Lease.analyzeLeaseVsBuy terms startDate
-        
-        analysis.LeaseDetails.LeasePayment |> should equal 300_00L<Cent>
+        let analysis = Lease.analyzeLeaseVsBuy terms startDate (Percent 8.0m)
+
+        analysis.LeaseDetails.LeasePayment |> should equal 218_14L<Cent>
         analysis.PurchaseDepreciation |> should not' (be Empty)
         analysis.LeaseSchedule.Length |> should equal 36
+
+        // "manufacturing equipment" is a recognized 7-year classification, not an assumption
+        analysis.AssetClassAssumed |> should equal false
+
+        // discounting a 5% lease at 8% makes leasing advantageous: NAL must be positive
+        analysis.NetAdvantageToLeasing |> should be (greaterThan 0L<Cent>)
+
+        // discounting at the implicit rate makes both alternatives nearly equivalent
+        let atImplicit = Lease.analyzeLeaseVsBuy terms startDate (Percent 5.0m)
+        abs atImplicit.NetAdvantageToLeasing |> should be (lessThan 5_00L<Cent>)
+
+    [<Fact>]
+    let ``Recurring periodic fee appears as its own column and in totals`` () =
+        let baseTerms = {
+            EquipmentDescription = "Equipment"
+            FairMarketValue = 6000_00L<Cent>
+            TermMonths = 24
+            LeaseType = Lease.LeaseType.FinanceLease
+            PaymentFrequency = Lease.PaymentFrequency.Monthly
+            PaymentTiming = Lease.PaymentTiming.InArrears
+            LeasePayment = 220_45L<Cent>
+            PeriodicFee = None
+            UpfrontPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+            PurchaseOption = None
+            ImplicitRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 4.0m)
+        }
+        let terms = { baseTerms with PeriodicFee = Some 15_00L<Cent> }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Lease.generateLeaseSchedule terms startDate
+
+        // the fee is identifiable in every row: payment = principal + interest + fee
+        schedule |> Array.iter (fun item ->
+            item.FeePortion |> should equal 15_00L<Cent>
+            item.PaymentAmount |> should equal (item.PrincipalPortion + item.InterestPortion + item.FeePortion))
+
+        // non-final payments are the stated rental plus the fee
+        schedule
+        |> Array.take (schedule.Length - 1)
+        |> Array.iter (fun item -> item.PaymentAmount |> should equal (220_45L<Cent> + 15_00L<Cent>))
+
+        // the fee does not change the liability amortization
+        let noFeeSchedule = Lease.generateLeaseSchedule baseTerms startDate
+        Array.zip schedule noFeeSchedule
+        |> Array.iter (fun (feeItem, noFeeItem) ->
+            feeItem.PrincipalPortion |> should equal noFeeItem.PrincipalPortion
+            feeItem.InterestPortion |> should equal noFeeItem.InterestPortion
+            feeItem.RemainingLiability |> should equal noFeeItem.RemainingLiability)
+
+        // totals include the fees, reported separately
+        let details = Lease.calculateLeaseDetails terms
+        let noFeeDetails = Lease.calculateLeaseDetails baseTerms
+        details.TotalFees |> should equal (24L * 15_00L<Cent>)
+        details.TotalPayments |> should equal (noFeeDetails.TotalPayments + details.TotalFees)
 
     [<Fact>]
     let ``Lease rejects term incompatible with payment frequency`` () =
@@ -324,7 +531,9 @@ module EquipmentLeaseTests =
             TermMonths = 13
             LeaseType = Lease.LeaseType.FinanceLease
             PaymentFrequency = Lease.PaymentFrequency.Quarterly
+            PaymentTiming = Lease.PaymentTiming.InArrears
             LeasePayment = 0L<Cent>
+            PeriodicFee = None
             UpfrontPayment = 0L<Cent>
             ResidualValue = 1000_00L<Cent>
             PurchaseOption = None

--- a/tests/EquipmentLoanTests.fs
+++ b/tests/EquipmentLoanTests.fs
@@ -16,6 +16,7 @@ module EquipmentLoanTests =
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Zero
             TermMonths = 12
             MonthlyPayment = None
+            MonthlyFee = None
             EquipmentDescription = "Test equipment"
             EquipmentCost = 1000_00L<Cent>
             DownPayment = 0L<Cent>
@@ -32,6 +33,7 @@ module EquipmentLoanTests =
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 6.0m)
             TermMonths = 36
             MonthlyPayment = None
+            MonthlyFee = None
             EquipmentDescription = "Manufacturing equipment"
             EquipmentCost = 10000_00L<Cent>
             DownPayment = 0L<Cent>
@@ -49,6 +51,7 @@ module EquipmentLoanTests =
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 6.0m)
             TermMonths = 36
             MonthlyPayment = None
+            MonthlyFee = None
             EquipmentDescription = "Manufacturing equipment"
             EquipmentCost = 10000_00L<Cent>
             DownPayment = 0L<Cent>
@@ -72,6 +75,7 @@ module EquipmentLoanTests =
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 5.0m)
             TermMonths = 24
             MonthlyPayment = None
+            MonthlyFee = None
             EquipmentDescription = "Office equipment"
             EquipmentCost = 5000_00L<Cent>
             DownPayment = 0L<Cent>
@@ -83,7 +87,7 @@ module EquipmentLoanTests =
         details.MonthlyPayment |> should be (greaterThan 0L<Cent>)
         details.TotalPayments |> should be (greaterThan terms.Principal)
         details.TotalInterest |> should be (greaterThan 0L<Cent>)
-        details.Apr |> should equal (FSharp.Finance.Personal.Calculation.Percent 5.0m)
+        details.NominalAnnualRate |> should equal (FSharp.Finance.Personal.Calculation.Percent 5.0m)
 
     [<Fact>]
     let ``Amortization schedule has correct length`` () =
@@ -92,6 +96,7 @@ module EquipmentLoanTests =
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
             TermMonths = 12
             MonthlyPayment = None
+            MonthlyFee = None
             EquipmentDescription = "Computer"
             EquipmentCost = 3000_00L<Cent>
             DownPayment = 0L<Cent>
@@ -119,6 +124,7 @@ module EquipmentLoanTests =
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 6.0m)
             TermMonths = 36
             MonthlyPayment = None
+            MonthlyFee = None
             EquipmentDescription = "Manufacturing equipment"
             EquipmentCost = 10000_00L<Cent>
             DownPayment = 0L<Cent>
@@ -139,6 +145,7 @@ module EquipmentLoanTests =
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Zero
             TermMonths = 0
             MonthlyPayment = None
+            MonthlyFee = None
             EquipmentDescription = "Test equipment"
             EquipmentCost = 1000_00L<Cent>
             DownPayment = 0L<Cent>
@@ -149,12 +156,189 @@ module EquipmentLoanTests =
         |> should throw typeof<System.ArgumentException>
 
     [<Fact>]
+    let ``Overpaying supplied payment terminates schedule early with non-negative balances`` () =
+        let terms = {
+            Principal = 10000_00L<Cent> // $10,000
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 6.0m)
+            TermMonths = 36
+            MonthlyPayment = Some 1000_00L<Cent> // $1,000/month heavily overpays
+            MonthlyFee = None
+            EquipmentDescription = "Manufacturing equipment"
+            EquipmentCost = 10000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 0L<Cent>
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Loan.generateAmortizationSchedule terms startDate
+
+        // schedule must end early, well before the 36-month nominal term
+        schedule.Length |> should be (lessThan 36)
+
+        // no negative balances, interest or payments anywhere
+        schedule |> Array.iter (fun item ->
+            item.RemainingBalance |> should be (greaterThanOrEqualTo 0L<Cent>)
+            item.InterestPayment |> should be (greaterThanOrEqualTo 0L<Cent>)
+            item.PrincipalPayment |> should be (greaterThanOrEqualTo 0L<Cent>)
+            item.PaymentAmount |> should be (greaterThanOrEqualTo 0L<Cent>))
+
+        // final payment clears the balance exactly
+        let last = schedule |> Array.last
+        last.RemainingBalance |> should equal 0L<Cent>
+        last.PaymentAmount |> should be (lessThanOrEqualTo 1000_00L<Cent>)
+
+        // total principal repaid equals the original principal
+        schedule |> Array.sumBy (fun item -> item.PrincipalPayment) |> should equal terms.Principal
+
+    [<Fact>]
+    let ``Supplied payment amortizes to residual with balloon in final payment`` () =
+        let terms = {
+            Principal = 10000_00L<Cent>
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 6.0m)
+            TermMonths = 36
+            MonthlyPayment = Some 250_00L<Cent>
+            MonthlyFee = None
+            EquipmentDescription = "Manufacturing equipment"
+            EquipmentCost = 10000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 2000_00L<Cent>
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Loan.generateAmortizationSchedule terms startDate
+        let last = schedule |> Array.last
+
+        // the residual must not be ignored: the balance amortizes down to it and the final
+        // payment settles it as a balloon
+        last.RemainingBalance |> should equal 0L<Cent>
+        last.BalloonAmount |> should equal 2000_00L<Cent>
+        last.PaymentAmount |> should be (greaterThanOrEqualTo 2000_00L<Cent>)
+        last.PaymentAmount |> should equal (last.InterestPayment + last.PrincipalPayment)
+
+        // balance never drops below the residual before the final payment
+        schedule
+        |> Array.take (schedule.Length - 1)
+        |> Array.iter (fun item ->
+            item.RemainingBalance |> should be (greaterThanOrEqualTo 2000_00L<Cent>)
+            item.BalloonAmount |> should equal 0L<Cent>)
+
+    [<Fact>]
+    let ``Supplied payment below first-period interest is rejected`` () =
+        let terms = {
+            Principal = 10000_00L<Cent>
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 12.0m)
+            TermMonths = 36
+            MonthlyPayment = Some 50_00L<Cent> // below the $100 first-month interest
+            MonthlyFee = None
+            EquipmentDescription = "Manufacturing equipment"
+            EquipmentCost = 10000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 0L<Cent>
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        (fun () -> Loan.generateAmortizationSchedule terms startDate |> ignore)
+        |> should throw typeof<System.ArgumentException>
+
+    [<Fact>]
+    let ``Interest-only balloon loan with residual equal to principal`` () =
+        let terms = {
+            Principal = 10000_00L<Cent>
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 6.0m)
+            TermMonths = 36
+            MonthlyPayment = None
+            MonthlyFee = None
+            EquipmentDescription = "Manufacturing equipment"
+            EquipmentCost = 10000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 10000_00L<Cent> // residual = principal: interest-only structure
+        }
+
+        // payment = P * i / 12 = 10,000 * 6% / 12 = $50.00
+        let payment = Loan.calculateMonthlyPayment terms
+        abs (payment - 50_00L<Cent>) |> should be (lessThanOrEqualTo 1L<Cent>)
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Loan.generateAmortizationSchedule terms startDate
+
+        schedule.Length |> should equal 36
+
+        // no principal is repaid until the final balloon
+        schedule
+        |> Array.take 35
+        |> Array.iter (fun item ->
+            item.PrincipalPayment |> should equal 0L<Cent>
+            item.RemainingBalance |> should equal 10000_00L<Cent>)
+
+        // final payment includes the full principal as balloon
+        let last = schedule |> Array.last
+        last.PrincipalPayment |> should equal 10000_00L<Cent>
+        last.BalloonAmount |> should equal 10000_00L<Cent>
+        last.RemainingBalance |> should equal 0L<Cent>
+
+    [<Fact>]
+    let ``Residual above principal is rejected`` () =
+        let terms = {
+            Principal = 10000_00L<Cent>
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 6.0m)
+            TermMonths = 36
+            MonthlyPayment = None
+            MonthlyFee = None
+            EquipmentDescription = "Manufacturing equipment"
+            EquipmentCost = 10000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 10000_01L<Cent>
+        }
+
+        (fun () -> Loan.calculateMonthlyPayment terms |> ignore)
+        |> should throw typeof<System.ArgumentException>
+
+    [<Fact>]
+    let ``Recurring monthly fee appears as its own column and in totals`` () =
+        let baseTerms = {
+            Principal = 5000_00L<Cent>
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 5.0m)
+            TermMonths = 24
+            MonthlyPayment = None
+            MonthlyFee = None
+            EquipmentDescription = "Office equipment"
+            EquipmentCost = 5000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 0L<Cent>
+        }
+        let terms = { baseTerms with MonthlyFee = Some 10_00L<Cent> }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Loan.generateAmortizationSchedule terms startDate
+
+        // the fee is identifiable in every row: payment = principal + interest + fee
+        schedule |> Array.iter (fun item ->
+            item.FeePayment |> should equal 10_00L<Cent>
+            item.PaymentAmount |> should equal (item.PrincipalPayment + item.InterestPayment + item.FeePayment))
+
+        // the fee does not change the amortization itself
+        let noFeeSchedule = Loan.generateAmortizationSchedule baseTerms startDate
+        Array.zip schedule noFeeSchedule
+        |> Array.iter (fun (feeItem, noFeeItem) ->
+            feeItem.PrincipalPayment |> should equal noFeeItem.PrincipalPayment
+            feeItem.InterestPayment |> should equal noFeeItem.InterestPayment
+            feeItem.RemainingBalance |> should equal noFeeItem.RemainingBalance)
+
+        // totals include the fees, reported separately
+        let details = Loan.calculatePaymentDetails terms
+        let noFeeDetails = Loan.calculatePaymentDetails baseTerms
+        details.TotalFees |> should equal (24L * 10_00L<Cent>)
+        details.TotalPayments |> should equal (noFeeDetails.TotalPayments + details.TotalFees)
+        details.TotalInterest |> should equal noFeeDetails.TotalInterest
+
+    [<Fact>]
     let ``Loan analysis includes depreciation schedule`` () =
         let terms = {
             Principal = 10000_00L<Cent> // $10,000
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 6.0m)
             TermMonths = 36
             MonthlyPayment = None
+            MonthlyFee = None
             EquipmentDescription = "Manufacturing equipment"
             EquipmentCost = 10000_00L<Cent>
             DownPayment = 2000_00L<Cent>
@@ -162,8 +346,17 @@ module EquipmentLoanTests =
         }
         
         let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
-        let analysis = Loan.analyzeLoan terms startDate
-        
+        let analysis = Loan.analyzeLoan terms startDate (Percent 8.0m)
+
         analysis.PaymentDetails.MonthlyPayment |> should be (greaterThan 0L<Cent>)
         analysis.DepreciationSchedule |> should not' (be Empty)
         analysis.AmortizationSchedule.Length |> should equal 36
+
+        // "manufacturing equipment" is a recognized 7-year classification, not an assumption
+        analysis.AssetClassAssumed |> should equal false
+
+        // NPV of the cash outflows: between the sum of undiscounted payments and zero,
+        // and at least the down payment
+        analysis.NetPresentValue |> should be (greaterThan terms.DownPayment)
+        analysis.NetPresentValue
+        |> should be (lessThan (terms.DownPayment + analysis.PaymentDetails.TotalPayments))

--- a/tests/EquipmentLoanTests.fs
+++ b/tests/EquipmentLoanTests.fs
@@ -3,74 +3,76 @@ namespace FSharp.Finance.Personal.Tests
 open Xunit
 open FsUnit.Xunit
 
+open FSharp.Finance.Personal.Calculation
 open FSharp.Finance.Personal.EquipmentFinance
+open FSharp.Finance.Personal.EquipmentFinance.Loan
 
 module EquipmentLoanTests =
 
     [<Fact>]
     let ``Monthly payment calculation works for zero interest`` () =
         let terms = {
-            Principal = 100000L<FSharp.Finance.Personal.Calculation.Cent> // $1,000
+            Principal = 1000_00L<Cent> // $1,000
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Zero
             TermMonths = 12
             MonthlyPayment = None
             EquipmentDescription = "Test equipment"
-            EquipmentCost = 100000L<FSharp.Finance.Personal.Calculation.Cent>
-            DownPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            EquipmentCost = 1000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 0L<Cent>
         }
         
         let payment = Loan.calculateMonthlyPayment terms
-        payment |> should equal 8333L<FSharp.Finance.Personal.Calculation.Cent> // $1000/12 ≈ $83.33
+        payment |> should equal 8333L<Cent> // $1000/12 ≈ $83.33
 
     [<Fact>]
     let ``Monthly payment calculation works with interest`` () =
         let terms = {
-            Principal = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            Principal = 10000_00L<Cent> // $10,000
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 6.0m)
             TermMonths = 36
             MonthlyPayment = None
             EquipmentDescription = "Manufacturing equipment"
-            EquipmentCost = 1000000L<FSharp.Finance.Personal.Calculation.Cent>
-            DownPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            EquipmentCost = 10000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 0L<Cent>
         }
         
         let payment = Loan.calculateMonthlyPayment terms
         // Payment should be greater than simple division due to interest
-        payment |> should be (greaterThan 27777L<FSharp.Finance.Personal.Calculation.Cent>) // $10000/36
+        payment |> should be (greaterThan 27777L<Cent>) // $10000/36
 
     [<Fact>]
     let ``Payment details calculation includes total payments and interest`` () =
         let terms = {
-            Principal = 500000L<FSharp.Finance.Personal.Calculation.Cent> // $5,000
+            Principal = 5000_00L<Cent> // $5,000
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 5.0m)
             TermMonths = 24
             MonthlyPayment = None
             EquipmentDescription = "Office equipment"
-            EquipmentCost = 500000L<FSharp.Finance.Personal.Calculation.Cent>
-            DownPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            EquipmentCost = 5000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 0L<Cent>
         }
         
         let details = Loan.calculatePaymentDetails terms
         
-        details.MonthlyPayment |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        details.MonthlyPayment |> should be (greaterThan 0L<Cent>)
         details.TotalPayments |> should be (greaterThan terms.Principal)
-        details.TotalInterest |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        details.TotalInterest |> should be (greaterThan 0L<Cent>)
         details.Apr |> should equal (FSharp.Finance.Personal.Calculation.Percent 5.0m)
 
     [<Fact>]
     let ``Amortization schedule has correct length`` () =
         let terms = {
-            Principal = 300000L<FSharp.Finance.Personal.Calculation.Cent> // $3,000
+            Principal = 3000_00L<Cent> // $3,000
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
             TermMonths = 12
             MonthlyPayment = None
             EquipmentDescription = "Computer"
-            EquipmentCost = 300000L<FSharp.Finance.Personal.Calculation.Cent>
-            DownPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            EquipmentCost = 3000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 0L<Cent>
         }
         
         let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
@@ -85,24 +87,24 @@ module EquipmentLoanTests =
         schedule.[11].PaymentNumber |> should equal 12
         
         // Final balance should be 0 (or residual value)
-        schedule.[11].RemainingBalance |> should equal 0L<FSharp.Finance.Personal.Calculation.Cent>
+        schedule.[11].RemainingBalance |> should equal 0L<Cent>
 
     [<Fact>]
     let ``Loan analysis includes depreciation schedule`` () =
         let terms = {
-            Principal = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            Principal = 10000_00L<Cent> // $10,000
             InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 6.0m)
             TermMonths = 36
             MonthlyPayment = None
             EquipmentDescription = "Manufacturing equipment"
-            EquipmentCost = 1000000L<FSharp.Finance.Personal.Calculation.Cent>
-            DownPayment = 200000L<FSharp.Finance.Personal.Calculation.Cent>
-            ResidualValue = 100000L<FSharp.Finance.Personal.Calculation.Cent>
+            EquipmentCost = 10000_00L<Cent>
+            DownPayment = 2000_00L<Cent>
+            ResidualValue = 1000_00L<Cent>
         }
         
         let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
         let analysis = Loan.analyzeLoan terms startDate
         
-        analysis.PaymentDetails.MonthlyPayment |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        analysis.PaymentDetails.MonthlyPayment |> should be (greaterThan 0L<Cent>)
         analysis.DepreciationSchedule |> should not' (be Empty)
         analysis.AmortizationSchedule.Length |> should equal 36

--- a/tests/EquipmentLoanTests.fs
+++ b/tests/EquipmentLoanTests.fs
@@ -43,6 +43,29 @@ module EquipmentLoanTests =
         payment |> should be (greaterThan 27777L<Cent>) // $10000/36
 
     [<Fact>]
+    let ``Monthly payment discounts balloon residual at non-zero interest`` () =
+        let terms = {
+            Principal = 10000_00L<Cent>
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 6.0m)
+            TermMonths = 36
+            MonthlyPayment = None
+            EquipmentDescription = "Manufacturing equipment"
+            EquipmentCost = 10000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 2000_00L<Cent>
+        }
+
+        let payment = Loan.calculateMonthlyPayment terms
+        let r = 0.06m / 12m
+        let n = 36
+        let growth = System.Math.Pow(float (1m + r), float n) |> decimal
+        let pvResidual = 2000.00m / growth
+        let amortizedPrincipal = 10000.00m - pvResidual
+        let expected = amortizedPrincipal * r * growth / (growth - 1m) |> Cent.fromDecimal
+
+        abs (payment - expected) |> should be (lessThanOrEqualTo 1L<Cent>)
+
+    [<Fact>]
     let ``Payment details calculation includes total payments and interest`` () =
         let terms = {
             Principal = 5000_00L<Cent> // $5,000
@@ -88,6 +111,42 @@ module EquipmentLoanTests =
         
         // Final balance should be 0 (or residual value)
         schedule.[11].RemainingBalance |> should equal 0L<Cent>
+
+    [<Fact>]
+    let ``Amortization schedule clears balloon on final payment`` () =
+        let terms = {
+            Principal = 10000_00L<Cent>
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (Percent 6.0m)
+            TermMonths = 36
+            MonthlyPayment = None
+            EquipmentDescription = "Manufacturing equipment"
+            EquipmentCost = 10000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 1000_00L<Cent>
+        }
+
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Loan.generateAmortizationSchedule terms startDate
+        let last = schedule |> Array.last
+
+        last.RemainingBalance |> should equal 0L<Cent>
+        last.PaymentAmount |> should be (greaterThan (Loan.calculateMonthlyPayment terms))
+
+    [<Fact>]
+    let ``Invalid loan terms are rejected`` () =
+        let invalidTerms = {
+            Principal = 1000_00L<Cent>
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Zero
+            TermMonths = 0
+            MonthlyPayment = None
+            EquipmentDescription = "Test equipment"
+            EquipmentCost = 1000_00L<Cent>
+            DownPayment = 0L<Cent>
+            ResidualValue = 0L<Cent>
+        }
+
+        (fun () -> Loan.calculateMonthlyPayment invalidTerms |> ignore)
+        |> should throw typeof<System.ArgumentException>
 
     [<Fact>]
     let ``Loan analysis includes depreciation schedule`` () =

--- a/tests/EquipmentLoanTests.fs
+++ b/tests/EquipmentLoanTests.fs
@@ -1,0 +1,108 @@
+namespace FSharp.Finance.Personal.Tests
+
+open Xunit
+open FsUnit.Xunit
+
+open FSharp.Finance.Personal.EquipmentFinance
+
+module EquipmentLoanTests =
+
+    [<Fact>]
+    let ``Monthly payment calculation works for zero interest`` () =
+        let terms = {
+            Principal = 100000L<FSharp.Finance.Personal.Calculation.Cent> // $1,000
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Zero
+            TermMonths = 12
+            MonthlyPayment = None
+            EquipmentDescription = "Test equipment"
+            EquipmentCost = 100000L<FSharp.Finance.Personal.Calculation.Cent>
+            DownPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 0L<FSharp.Finance.Personal.Calculation.Cent>
+        }
+        
+        let payment = Loan.calculateMonthlyPayment terms
+        payment |> should equal 8333L<FSharp.Finance.Personal.Calculation.Cent> // $1000/12 ≈ $83.33
+
+    [<Fact>]
+    let ``Monthly payment calculation works with interest`` () =
+        let terms = {
+            Principal = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 6.0m)
+            TermMonths = 36
+            MonthlyPayment = None
+            EquipmentDescription = "Manufacturing equipment"
+            EquipmentCost = 1000000L<FSharp.Finance.Personal.Calculation.Cent>
+            DownPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 0L<FSharp.Finance.Personal.Calculation.Cent>
+        }
+        
+        let payment = Loan.calculateMonthlyPayment terms
+        // Payment should be greater than simple division due to interest
+        payment |> should be (greaterThan 27777L<FSharp.Finance.Personal.Calculation.Cent>) // $10000/36
+
+    [<Fact>]
+    let ``Payment details calculation includes total payments and interest`` () =
+        let terms = {
+            Principal = 500000L<FSharp.Finance.Personal.Calculation.Cent> // $5,000
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 5.0m)
+            TermMonths = 24
+            MonthlyPayment = None
+            EquipmentDescription = "Office equipment"
+            EquipmentCost = 500000L<FSharp.Finance.Personal.Calculation.Cent>
+            DownPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 0L<FSharp.Finance.Personal.Calculation.Cent>
+        }
+        
+        let details = Loan.calculatePaymentDetails terms
+        
+        details.MonthlyPayment |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        details.TotalPayments |> should be (greaterThan terms.Principal)
+        details.TotalInterest |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        details.Apr |> should equal (FSharp.Finance.Personal.Calculation.Percent 5.0m)
+
+    [<Fact>]
+    let ``Amortization schedule has correct length`` () =
+        let terms = {
+            Principal = 300000L<FSharp.Finance.Personal.Calculation.Cent> // $3,000
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 4.0m)
+            TermMonths = 12
+            MonthlyPayment = None
+            EquipmentDescription = "Computer"
+            EquipmentCost = 300000L<FSharp.Finance.Personal.Calculation.Cent>
+            DownPayment = 0L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 0L<FSharp.Finance.Personal.Calculation.Cent>
+        }
+        
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let schedule = Loan.generateAmortizationSchedule terms startDate
+        
+        schedule.Length |> should equal 12
+        
+        // First payment should have payment number 1
+        schedule.[0].PaymentNumber |> should equal 1
+        
+        // Last payment should have payment number equal to term
+        schedule.[11].PaymentNumber |> should equal 12
+        
+        // Final balance should be 0 (or residual value)
+        schedule.[11].RemainingBalance |> should equal 0L<FSharp.Finance.Personal.Calculation.Cent>
+
+    [<Fact>]
+    let ``Loan analysis includes depreciation schedule`` () =
+        let terms = {
+            Principal = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            InterestRate = FSharp.Finance.Personal.Interest.Rate.Annual (FSharp.Finance.Personal.Calculation.Percent 6.0m)
+            TermMonths = 36
+            MonthlyPayment = None
+            EquipmentDescription = "Manufacturing equipment"
+            EquipmentCost = 1000000L<FSharp.Finance.Personal.Calculation.Cent>
+            DownPayment = 200000L<FSharp.Finance.Personal.Calculation.Cent>
+            ResidualValue = 100000L<FSharp.Finance.Personal.Calculation.Cent>
+        }
+        
+        let startDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+        let analysis = Loan.analyzeLoan terms startDate
+        
+        analysis.PaymentDetails.MonthlyPayment |> should be (greaterThan 0L<FSharp.Finance.Personal.Calculation.Cent>)
+        analysis.DepreciationSchedule |> should not' (be Empty)
+        analysis.AmortizationSchedule.Length |> should equal 36

--- a/tests/FSharp.Finance.Personal.Tests.fsproj
+++ b/tests/FSharp.Finance.Personal.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <!-- <Compile Include="UnitPeriodConfigTests.fs" /> -->
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="9.0.201" />
+    <PackageReference Update="FSharp.Core" Version="8.0.300" />
     <PackageReference Include="FsUnit" Version="5.5.0" />
     <PackageReference Include="FsUnit.Xunit" Version="5.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />

--- a/tests/FSharp.Finance.Personal.Tests.fsproj
+++ b/tests/FSharp.Finance.Personal.Tests.fsproj
@@ -26,6 +26,11 @@
     <Compile Include="PromotionalRatesTests.fs" />
     <Compile Include="QuoteTests.fs" />
     <Compile Include="SettlementTests.fs" />
+    <Compile Include="DepreciationCommonTests.fs" />
+    <Compile Include="UKCapitalAllowancesTests.fs" />
+    <Compile Include="USMacrsTests.fs" />
+    <Compile Include="EquipmentLoanTests.fs" />
+    <Compile Include="EquipmentLeaseTests.fs" />
     <!-- <Compile Include="UnitPeriodConfigTests.fs" /> -->
   </ItemGroup>
   <ItemGroup>

--- a/tests/FSharp.Finance.Personal.Tests.fsproj
+++ b/tests/FSharp.Finance.Personal.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -34,7 +34,7 @@
     <!-- <Compile Include="UnitPeriodConfigTests.fs" /> -->
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.300" />
+    <PackageReference Update="FSharp.Core" Version="9.0.201" />
     <PackageReference Include="FsUnit" Version="5.5.0" />
     <PackageReference Include="FsUnit.Xunit" Version="5.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />

--- a/tests/UKCapitalAllowancesTests.fs
+++ b/tests/UKCapitalAllowancesTests.fs
@@ -1,0 +1,136 @@
+namespace FSharp.Finance.Personal.Tests
+
+open Xunit
+open FsUnit.Xunit
+
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.UK_CapitalAllowances
+
+module UKCapitalAllowancesTests =
+
+    [<Fact>]
+    let ``Default configuration has expected values`` () =
+        Types.Default.AnnualInvestmentAllowanceLimit |> should equal 1_000_000m
+        Types.Default.MainPoolRate |> should equal 0.18m
+        Types.Default.SpecialRatePoolRate |> should equal 0.06m
+        Types.Default.MaxYears |> should equal 10
+
+    [<Fact>]
+    let ``Rounding function works correctly`` () =
+        Calculations.roundAwayFromZero 12.345m |> should equal 12.35m
+        Calculations.roundAwayFromZero 12.344m |> should equal 12.34m
+        Calculations.roundAwayFromZero 12.346m |> should equal 12.35m
+
+    [<Fact>]
+    let ``Small asset fully claimed via AIA in year 1`` () =
+        let expenditure = {
+            Amount = 5_000m
+            Pool = Types.Pool.Main
+            Description = "Small equipment"
+        }
+        
+        let schedule = Calculations.scheduleDefault expenditure
+        
+        // Should have at least one year
+        schedule |> should not' (be Empty)
+        
+        // First year should claim full amount via AIA
+        let year1 = schedule |> List.head
+        year1.Year |> should equal 1
+        year1.AnnualInvestmentAllowance |> should equal 5_000m
+        year1.WritingDownAllowance |> should equal 0m
+        year1.TotalAllowances |> should equal 5_000m
+        year1.PoolValueEndOfYear |> should equal 0m
+
+    [<Fact>]
+    let ``Large asset partially claimed via AIA then WDA`` () =
+        let expenditure = {
+            Amount = 50_000m
+            Pool = Types.Pool.Main
+            Description = "Large equipment"
+        }
+        
+        let customConfig = {
+            Types.Default with
+                AnnualInvestmentAllowanceLimit = 10_000m
+                MaxYears = 3
+        }
+        
+        let schedule = Calculations.generateSchedule customConfig expenditure
+        
+        // Should have multiple years
+        schedule.Length |> should be (greaterThan 1)
+        
+        // First year: £10k AIA, £7.2k WDA (18% of remaining £40k)
+        let year1 = schedule |> List.head
+        year1.Year |> should equal 1
+        year1.AnnualInvestmentAllowance |> should equal 10_000m
+        year1.WritingDownAllowance |> should equal 7_200m // 18% of 40k
+        year1.TotalAllowances |> should equal 17_200m
+        year1.PoolValueEndOfYear |> should equal 32_800m // 40k - 7.2k
+
+    [<Fact>]
+    let ``Special rate pool uses 6% WDA rate`` () =
+        let expenditure = {
+            Amount = 30_000m
+            Pool = Types.Pool.SpecialRate
+            Description = "Vehicle"
+        }
+        
+        let customConfig = {
+            Types.Default with
+                AnnualInvestmentAllowanceLimit = 20_000m
+                MaxYears = 2
+        }
+        
+        let schedule = Calculations.generateSchedule customConfig expenditure
+        
+        // First year: £20k AIA, £0.6k WDA (6% of remaining £10k)
+        let year1 = schedule |> List.head
+        year1.AnnualInvestmentAllowance |> should equal 20_000m
+        year1.WritingDownAllowance |> should equal 600m // 6% of 10k
+        year1.PoolValueEndOfYear |> should equal 9_400m
+
+    [<Fact>]
+    let ``Example machinery schedule works`` () =
+        let schedule = Examples.exampleMachinerySchedule ()
+        
+        schedule |> should not' (be Empty)
+        
+        let year1 = schedule |> List.head
+        year1.AnnualInvestmentAllowance |> should equal 50_000m // Full amount via AIA
+        year1.WritingDownAllowance |> should equal 0m
+        year1.TotalAllowances |> should equal 50_000m
+
+    [<Fact>]
+    let ``Example vehicle schedule works`` () =
+        let schedule = Examples.exampleVehicleSchedule ()
+        
+        schedule |> should not' (be Empty)
+        
+        let year1 = schedule |> List.head
+        year1.AnnualInvestmentAllowance |> should equal 30_000m // Full amount via AIA
+        year1.WritingDownAllowance |> should equal 0m
+        year1.TotalAllowances |> should equal 30_000m
+
+    [<Fact>]
+    let ``Schedule continues until pool value is zero or max years reached`` () =
+        let expenditure = {
+            Amount = 1_000m
+            Pool = Types.Pool.Main
+            Description = "Small equipment"
+        }
+        
+        let customConfig = {
+            Types.Default with
+                AnnualInvestmentAllowanceLimit = 0m // No AIA
+                MaxYears = 20
+        }
+        
+        let schedule = Calculations.generateSchedule customConfig expenditure
+        
+        // Should continue for multiple years until pool depleted
+        schedule.Length |> should be (greaterThan 5)
+        
+        // Last year should have pool value of 0 or very small
+        let lastYear = schedule |> List.last
+        lastYear.PoolValueEndOfYear |> should be (lessThanOrEqualTo 1m)

--- a/tests/UKCapitalAllowancesTests.fs
+++ b/tests/UKCapitalAllowancesTests.fs
@@ -16,6 +16,7 @@ module UKCapitalAllowancesTests =
         Types.Default.MainPoolRate |> should equal 0.18m
         Types.Default.SpecialRatePoolRate |> should equal 0.06m
         Types.Default.MaxYears |> should equal 10
+        Types.Default.SmallPoolThreshold |> should equal 1_000_00L<Cent>
 
     [<Fact>]
     let ``Small asset fully claimed via AIA in year 1`` () =
@@ -24,12 +25,12 @@ module UKCapitalAllowancesTests =
             Pool = Types.Pool.Main
             Description = "Small equipment"
         }
-        
-        let schedule = Calculations.scheduleDefault expenditure
-        
+
+        let schedule = (Calculations.scheduleDefault expenditure).Years
+
         // Should have at least one year
         schedule |> should not' (be Empty)
-        
+
         // First year should claim full amount via AIA
         let year1 = schedule |> List.head
         year1.Year |> should equal 1
@@ -45,18 +46,18 @@ module UKCapitalAllowancesTests =
             Pool = Types.Pool.Main
             Description = "Large equipment"
         }
-        
+
         let customConfig = {
             Types.Default with
                 AnnualInvestmentAllowanceLimit = 10_000_00L<Cent>
                 MaxYears = 3
         }
-        
-        let schedule = Calculations.generateSchedule customConfig expenditure
-        
+
+        let schedule = (Calculations.generateSchedule customConfig expenditure).Years
+
         // Should have multiple years
         schedule.Length |> should be (greaterThan 1)
-        
+
         // First year: £10k AIA, £7.2k WDA (18% of remaining £40k)
         let year1 = schedule |> List.head
         year1.Year |> should equal 1
@@ -72,15 +73,15 @@ module UKCapitalAllowancesTests =
             Pool = Types.Pool.SpecialRate
             Description = "Vehicle"
         }
-        
+
         let customConfig = {
             Types.Default with
                 AnnualInvestmentAllowanceLimit = 20_000_00L<Cent>
                 MaxYears = 2
         }
-        
-        let schedule = Calculations.generateSchedule customConfig expenditure
-        
+
+        let schedule = (Calculations.generateSchedule customConfig expenditure).Years
+
         // First year: £20k AIA, £0.6k WDA (6% of remaining £10k)
         let year1 = schedule |> List.head
         year1.AnnualInvestmentAllowance |> should equal 20_000_00L<Cent>
@@ -89,10 +90,10 @@ module UKCapitalAllowancesTests =
 
     [<Fact>]
     let ``Example machinery schedule works`` () =
-        let schedule = Examples.exampleMachinerySchedule ()
-        
+        let schedule = (Examples.exampleMachinerySchedule ()).Years
+
         schedule |> should not' (be Empty)
-        
+
         let year1 = schedule |> List.head
         year1.AnnualInvestmentAllowance |> should equal 50_000_00L<Cent> // Full amount via AIA
         year1.WritingDownAllowance |> should equal 0_00L<Cent>
@@ -100,37 +101,66 @@ module UKCapitalAllowancesTests =
 
     [<Fact>]
     let ``Example vehicle schedule works`` () =
-        let schedule = Examples.exampleVehicleSchedule ()
-        
+        let schedule = (Examples.exampleVehicleSchedule ()).Years
+
         schedule |> should not' (be Empty)
-        
+
         let year1 = schedule |> List.head
         year1.AnnualInvestmentAllowance |> should equal 30_000_00L<Cent> // Full amount via AIA
         year1.WritingDownAllowance |> should equal 0_00L<Cent>
         year1.TotalAllowances |> should equal 30_000_00L<Cent>
 
     [<Fact>]
-    let ``Schedule continues until pool value is zero or max years reached`` () =
+    let ``Schedule continues until pool is written off via small pools allowance`` () =
         let expenditure = {
-            Amount = 1_000_00L<Cent>
+            Amount = 50_000_00L<Cent>
             Pool = Types.Pool.Main
-            Description = "Small equipment"
+            Description = "Equipment"
         }
-        
+
         let customConfig = {
             Types.Default with
                 AnnualInvestmentAllowanceLimit = 0_00L<Cent> // No AIA
                 MaxYears = 50
         }
-        
-        let schedule = Calculations.generateSchedule customConfig expenditure
-        
-        // Should continue for multiple years until pool depleted
+
+        let result = Calculations.generateSchedule customConfig expenditure
+        let schedule = result.Years
+
+        // Should continue for multiple years until the pool drops to the small pools threshold
         schedule.Length |> should be (greaterThan 15)
-        
-        // Last year should have pool value of 0 or very small
+        schedule.Length |> should be (lessThan 50)
+
+        // Last year writes off the remaining small pool in full - nothing left unclaimed
         let lastYear = schedule |> List.last
-        lastYear.PoolValueEndOfYear |> should be (lessThanOrEqualTo 1_00L<Cent>)
+        lastYear.PoolValueEndOfYear |> should equal 0L<Cent>
+        result.UnclaimedPool |> should equal 0L<Cent>
+
+        // Total allowances over the schedule equal the original expenditure
+        schedule |> List.sumBy (fun year -> year.TotalAllowances) |> should equal expenditure.Amount
+
+    [<Fact>]
+    let ``Pool at or below small pools threshold is written off in full`` () =
+        let expenditure = {
+            Amount = 1_000_00L<Cent> // exactly £1,000
+            Pool = Types.Pool.Main
+            Description = "Small pool"
+        }
+
+        let customConfig = {
+            Types.Default with
+                AnnualInvestmentAllowanceLimit = 0L<Cent>
+                MaxYears = 10
+        }
+
+        let result = Calculations.generateSchedule customConfig expenditure
+        let schedule = result.Years
+
+        schedule.Length |> should equal 1
+        let year1 = schedule |> List.head
+        year1.WritingDownAllowance |> should equal 1_000_00L<Cent>
+        year1.PoolValueEndOfYear |> should equal 0L<Cent>
+        result.UnclaimedPool |> should equal 0L<Cent>
 
     [<Fact>]
     let ``Tiny residual pool is cleared instead of repeating zero WDA years`` () =
@@ -146,10 +176,40 @@ module UKCapitalAllowancesTests =
                 MaxYears = 10
         }
 
-        let schedule = Calculations.generateSchedule customConfig expenditure
+        let schedule = (Calculations.generateSchedule customConfig expenditure).Years
         let lastYear = schedule |> List.last
 
         schedule.Length |> should be (lessThanOrEqualTo 2)
         schedule |> List.exists (fun year -> year.WritingDownAllowance = 0L<Cent> && year.PoolValueEndOfYear > 0L<Cent>) |> should equal false
         lastYear.WritingDownAllowance |> should be (greaterThan 0L<Cent>)
         lastYear.PoolValueEndOfYear |> should equal 0L<Cent>
+
+    [<Fact>]
+    let ``Truncation at MaxYears reports the unclaimed pool`` () =
+        // audited scenario: a large special-rate pool truncated at the default 10 years
+        // used to abandon the residual with no flag
+        let expenditure = {
+            Amount = 200_000_00L<Cent>
+            Pool = Types.Pool.SpecialRate
+            Description = "Long-life asset"
+        }
+
+        let customConfig = {
+            Types.Default with
+                AnnualInvestmentAllowanceLimit = 0L<Cent>
+                MaxYears = 10
+        }
+
+        let result = Calculations.generateSchedule customConfig expenditure
+        let schedule = result.Years
+
+        schedule.Length |> should equal 10
+
+        // the unclaimed residual is visible and consistent with the schedule
+        let lastYear = schedule |> List.last
+        result.UnclaimedPool |> should equal lastYear.PoolValueEndOfYear
+        result.UnclaimedPool |> should be (greaterThan 0L<Cent>)
+
+        // claimed + unclaimed = original expenditure
+        let totalClaimed = schedule |> List.sumBy (fun year -> year.TotalAllowances)
+        totalClaimed + result.UnclaimedPool |> should equal expenditure.Amount

--- a/tests/UKCapitalAllowancesTests.fs
+++ b/tests/UKCapitalAllowancesTests.fs
@@ -3,27 +3,24 @@ namespace FSharp.Finance.Personal.Tests
 open Xunit
 open FsUnit.Xunit
 
+open FSharp.Finance.Personal
+open FSharp.Finance.Personal.Calculation
 open FSharp.Finance.Personal.EquipmentFinance.Depreciation.UK_CapitalAllowances
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.UK_CapitalAllowances.Types
 
 module UKCapitalAllowancesTests =
 
     [<Fact>]
     let ``Default configuration has expected values`` () =
-        Types.Default.AnnualInvestmentAllowanceLimit |> should equal 1_000_000m
+        Types.Default.AnnualInvestmentAllowanceLimit |> should equal 1_000_000_00L<Cent>
         Types.Default.MainPoolRate |> should equal 0.18m
         Types.Default.SpecialRatePoolRate |> should equal 0.06m
         Types.Default.MaxYears |> should equal 10
 
     [<Fact>]
-    let ``Rounding function works correctly`` () =
-        Calculations.roundAwayFromZero 12.345m |> should equal 12.35m
-        Calculations.roundAwayFromZero 12.344m |> should equal 12.34m
-        Calculations.roundAwayFromZero 12.346m |> should equal 12.35m
-
-    [<Fact>]
     let ``Small asset fully claimed via AIA in year 1`` () =
         let expenditure = {
-            Amount = 5_000m
+            Amount = 5_000_00L<Cent>
             Pool = Types.Pool.Main
             Description = "Small equipment"
         }
@@ -36,22 +33,22 @@ module UKCapitalAllowancesTests =
         // First year should claim full amount via AIA
         let year1 = schedule |> List.head
         year1.Year |> should equal 1
-        year1.AnnualInvestmentAllowance |> should equal 5_000m
-        year1.WritingDownAllowance |> should equal 0m
-        year1.TotalAllowances |> should equal 5_000m
-        year1.PoolValueEndOfYear |> should equal 0m
+        year1.AnnualInvestmentAllowance |> should equal 5_000_00L<Cent>
+        year1.WritingDownAllowance |> should equal 0L<Cent>
+        year1.TotalAllowances |> should equal 5_000_00L<Cent>
+        year1.PoolValueEndOfYear |> should equal 0L<Cent>
 
     [<Fact>]
     let ``Large asset partially claimed via AIA then WDA`` () =
         let expenditure = {
-            Amount = 50_000m
+            Amount = 50_000_00L<Cent>
             Pool = Types.Pool.Main
             Description = "Large equipment"
         }
         
         let customConfig = {
             Types.Default with
-                AnnualInvestmentAllowanceLimit = 10_000m
+                AnnualInvestmentAllowanceLimit = 10_000_00L<Cent>
                 MaxYears = 3
         }
         
@@ -63,22 +60,22 @@ module UKCapitalAllowancesTests =
         // First year: £10k AIA, £7.2k WDA (18% of remaining £40k)
         let year1 = schedule |> List.head
         year1.Year |> should equal 1
-        year1.AnnualInvestmentAllowance |> should equal 10_000m
-        year1.WritingDownAllowance |> should equal 7_200m // 18% of 40k
-        year1.TotalAllowances |> should equal 17_200m
-        year1.PoolValueEndOfYear |> should equal 32_800m // 40k - 7.2k
+        year1.AnnualInvestmentAllowance |> should equal 10_000_00L<Cent>
+        year1.WritingDownAllowance |> should equal 7_200_00L<Cent> // 18% of 40k
+        year1.TotalAllowances |> should equal 17_200_00L<Cent>
+        year1.PoolValueEndOfYear |> should equal 32_800_00L<Cent> // 40k - 7.2k
 
     [<Fact>]
     let ``Special rate pool uses 6% WDA rate`` () =
         let expenditure = {
-            Amount = 30_000m
+            Amount = 30_000_00L<Cent>
             Pool = Types.Pool.SpecialRate
             Description = "Vehicle"
         }
         
         let customConfig = {
             Types.Default with
-                AnnualInvestmentAllowanceLimit = 20_000m
+                AnnualInvestmentAllowanceLimit = 20_000_00L<Cent>
                 MaxYears = 2
         }
         
@@ -86,9 +83,9 @@ module UKCapitalAllowancesTests =
         
         // First year: £20k AIA, £0.6k WDA (6% of remaining £10k)
         let year1 = schedule |> List.head
-        year1.AnnualInvestmentAllowance |> should equal 20_000m
-        year1.WritingDownAllowance |> should equal 600m // 6% of 10k
-        year1.PoolValueEndOfYear |> should equal 9_400m
+        year1.AnnualInvestmentAllowance |> should equal 20_000_00L<Cent>
+        year1.WritingDownAllowance |> should equal 600_00L<Cent> // 6% of 10k
+        year1.PoolValueEndOfYear |> should equal 9_400_00L<Cent>
 
     [<Fact>]
     let ``Example machinery schedule works`` () =
@@ -97,9 +94,9 @@ module UKCapitalAllowancesTests =
         schedule |> should not' (be Empty)
         
         let year1 = schedule |> List.head
-        year1.AnnualInvestmentAllowance |> should equal 50_000m // Full amount via AIA
-        year1.WritingDownAllowance |> should equal 0m
-        year1.TotalAllowances |> should equal 50_000m
+        year1.AnnualInvestmentAllowance |> should equal 50_000_00L<Cent> // Full amount via AIA
+        year1.WritingDownAllowance |> should equal 0_00L<Cent>
+        year1.TotalAllowances |> should equal 50_000_00L<Cent>
 
     [<Fact>]
     let ``Example vehicle schedule works`` () =
@@ -108,29 +105,29 @@ module UKCapitalAllowancesTests =
         schedule |> should not' (be Empty)
         
         let year1 = schedule |> List.head
-        year1.AnnualInvestmentAllowance |> should equal 30_000m // Full amount via AIA
-        year1.WritingDownAllowance |> should equal 0m
-        year1.TotalAllowances |> should equal 30_000m
+        year1.AnnualInvestmentAllowance |> should equal 30_000_00L<Cent> // Full amount via AIA
+        year1.WritingDownAllowance |> should equal 0_00L<Cent>
+        year1.TotalAllowances |> should equal 30_000_00L<Cent>
 
     [<Fact>]
     let ``Schedule continues until pool value is zero or max years reached`` () =
         let expenditure = {
-            Amount = 1_000m
+            Amount = 1_000_00L<Cent>
             Pool = Types.Pool.Main
             Description = "Small equipment"
         }
         
         let customConfig = {
             Types.Default with
-                AnnualInvestmentAllowanceLimit = 0m // No AIA
-                MaxYears = 20
+                AnnualInvestmentAllowanceLimit = 0_00L<Cent> // No AIA
+                MaxYears = 50
         }
         
         let schedule = Calculations.generateSchedule customConfig expenditure
         
         // Should continue for multiple years until pool depleted
-        schedule.Length |> should be (greaterThan 5)
+        schedule.Length |> should be (greaterThan 15)
         
         // Last year should have pool value of 0 or very small
         let lastYear = schedule |> List.last
-        lastYear.PoolValueEndOfYear |> should be (lessThanOrEqualTo 1m)
+        lastYear.PoolValueEndOfYear |> should be (lessThanOrEqualTo 1_00L<Cent>)

--- a/tests/UKCapitalAllowancesTests.fs
+++ b/tests/UKCapitalAllowancesTests.fs
@@ -131,3 +131,25 @@ module UKCapitalAllowancesTests =
         // Last year should have pool value of 0 or very small
         let lastYear = schedule |> List.last
         lastYear.PoolValueEndOfYear |> should be (lessThanOrEqualTo 1_00L<Cent>)
+
+    [<Fact>]
+    let ``Tiny residual pool is cleared instead of repeating zero WDA years`` () =
+        let expenditure = {
+            Amount = 0_03L<Cent>
+            Pool = Types.Pool.Main
+            Description = "Tiny asset"
+        }
+
+        let customConfig = {
+            Types.Default with
+                AnnualInvestmentAllowanceLimit = 0L<Cent>
+                MaxYears = 10
+        }
+
+        let schedule = Calculations.generateSchedule customConfig expenditure
+        let lastYear = schedule |> List.last
+
+        schedule.Length |> should be (lessThanOrEqualTo 2)
+        schedule |> List.exists (fun year -> year.WritingDownAllowance = 0L<Cent> && year.PoolValueEndOfYear > 0L<Cent>) |> should equal false
+        lastYear.WritingDownAllowance |> should be (greaterThan 0L<Cent>)
+        lastYear.PoolValueEndOfYear |> should equal 0L<Cent>

--- a/tests/USMacrsTests.fs
+++ b/tests/USMacrsTests.fs
@@ -209,5 +209,54 @@ module USMacrsTests =
         Calculations.classifyAsset "car" |> should equal Types.AssetClass.FiveYear
         Calculations.classifyAsset "office furniture" |> should equal Types.AssetClass.SevenYear
         Calculations.classifyAsset "manufacturing equipment" |> should equal Types.AssetClass.SevenYear
-        Calculations.classifyAsset "building" |> should equal Types.AssetClass.FifteenYear
+        Calculations.classifyAsset "land improvement" |> should equal Types.AssetClass.FifteenYear
+        Calculations.classifyAsset "parking lot" |> should equal Types.AssetClass.FifteenYear
         Calculations.classifyAsset "general equipment" |> should equal Types.AssetClass.FiveYear // default
+
+    [<Fact>]
+    let ``Asset classification surfaces unrecognized descriptions`` () =
+        Calculations.tryClassifyAsset "computer equipment" |> should equal (Some Types.AssetClass.FiveYear)
+        Calculations.tryClassifyAsset "general equipment" |> should equal None
+
+    [<Fact>]
+    let ``Asset classification rejects real property`` () =
+        // buildings are 27.5/39-year straight-line real property under MACRS, not 15-year
+        (fun () -> Calculations.classifyAsset "building" |> ignore)
+        |> should throw typeof<System.ArgumentException>
+        (fun () -> Calculations.classifyAsset "warehouse" |> ignore)
+        |> should throw typeof<System.ArgumentException>
+
+    [<Fact>]
+    let ``Twenty-year table matches IRS Table A-1 and sums to exactly 100 percent`` () =
+        let percentages = Tables.getDepreciationPercentages Types.AssetClass.TwentyYear
+
+        percentages.Length |> should equal 21
+        percentages.[0] |> should equal 3.750m
+        percentages.[1] |> should equal 7.219m
+        percentages.[20] |> should equal 2.231m
+
+        // the IRS three-decimal values sum to exactly 100.000 (the previous two-decimal
+        // roundings summed to 100.01)
+        percentages |> Array.sum |> should equal 100.000m
+
+    [<Fact>]
+    let ``Twenty-year schedule on one million dollars sums exactly to basis`` () =
+        let asset = {
+            CostBasis = 1_000_000_00L<Cent> // $1,000,000
+            PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+            PropertyClass = Types.AssetClass.TwentyYear
+            Convention = Types.Convention.HalfYear
+        }
+
+        let schedule = Calculations.generateSchedule asset
+
+        schedule |> List.sumBy (fun year -> year.DepreciationAmount) |> should equal asset.CostBasis
+        (schedule |> List.last).BookValue |> should equal 0L<Cent>
+
+        // every year matches the table exactly - the basis cap safety net never distorts a year
+        schedule
+        |> List.iter (fun year ->
+            let expected =
+                decimal asset.CostBasis * year.DepreciationRate * 1m<Cent>
+                |> Cent.fromDecimalCent (RoundWith System.MidpointRounding.AwayFromZero)
+            year.DepreciationAmount |> should equal expected)

--- a/tests/USMacrsTests.fs
+++ b/tests/USMacrsTests.fs
@@ -1,0 +1,184 @@
+namespace FSharp.Finance.Personal.Tests
+
+open Xunit
+open FsUnit.Xunit
+
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
+
+module USMacrsTests =
+
+    [<Fact>]
+    let ``Asset class recovery periods are correct`` () =
+        Calculations.getRecoveryPeriod Types.AssetClass.ThreeYear |> should equal 3
+        Calculations.getRecoveryPeriod Types.AssetClass.FiveYear |> should equal 5
+        Calculations.getRecoveryPeriod Types.AssetClass.SevenYear |> should equal 7
+        Calculations.getRecoveryPeriod Types.AssetClass.TenYear |> should equal 10
+        Calculations.getRecoveryPeriod Types.AssetClass.FifteenYear |> should equal 15
+        Calculations.getRecoveryPeriod Types.AssetClass.TwentyYear |> should equal 20
+
+    [<Fact>]
+    let ``Five-year property percentages are available`` () =
+        let percentages = Tables.getDepreciationPercentages Types.AssetClass.FiveYear
+        
+        percentages.Length |> should equal 6
+        percentages.[0] |> should equal 20.00m
+        percentages.[1] |> should equal 32.00m
+        percentages.[2] |> should equal 19.20m
+        percentages.[3] |> should equal 11.52m
+        percentages.[4] |> should equal 11.52m
+        percentages.[5] |> should equal 5.76m
+
+    [<Fact>]
+    let ``Seven-year property percentages are available`` () =
+        let percentages = Tables.getDepreciationPercentages Types.AssetClass.SevenYear
+        
+        percentages.Length |> should equal 8
+        percentages.[0] |> should equal 14.29m
+        percentages.[1] |> should equal 24.49m
+
+    [<Fact>]
+    let ``Five-year asset depreciation schedule is correct`` () =
+        let asset = {
+            CostBasis = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+            PropertyClass = Types.AssetClass.FiveYear
+            Convention = Types.Convention.HalfYear
+        }
+        
+        let schedule = Calculations.generateSchedule asset
+        
+        schedule.Length |> should equal 6
+        
+        // Year 1: 20% of $10,000 = $2,000
+        let year1 = schedule |> List.head
+        year1.Year |> should equal 1
+        year1.DepreciationRate |> should equal 0.20m
+        year1.DepreciationAmount |> should equal 200000L<FSharp.Finance.Personal.Calculation.Cent> // $2,000
+        year1.AccumulatedDepreciation |> should equal 200000L<FSharp.Finance.Personal.Calculation.Cent>
+        year1.BookValue |> should equal 800000L<FSharp.Finance.Personal.Calculation.Cent>
+        
+        // Year 2: 32% of $10,000 = $3,200
+        let year2 = schedule.[1]
+        year2.Year |> should equal 2
+        year2.DepreciationRate |> should equal 0.32m
+        year2.DepreciationAmount |> should equal 320000L<FSharp.Finance.Personal.Calculation.Cent> // $3,200
+        year2.AccumulatedDepreciation |> should equal 520000L<FSharp.Finance.Personal.Calculation.Cent>
+        year2.BookValue |> should equal 480000L<FSharp.Finance.Personal.Calculation.Cent>
+
+    [<Fact>]
+    let ``Three-year asset depreciation schedule is correct`` () =
+        let asset = {
+            CostBasis = 300000L<FSharp.Finance.Personal.Calculation.Cent> // $3,000
+            PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+            PropertyClass = Types.AssetClass.ThreeYear
+            Convention = Types.Convention.HalfYear
+        }
+        
+        let schedule = Calculations.generateSchedule asset
+        
+        schedule.Length |> should equal 4
+        
+        // Year 1: 33.33% of $3,000 ≈ $999.90
+        let year1 = schedule |> List.head
+        year1.Year |> should equal 1
+        year1.DepreciationAmount |> should (equalWithin 100L<FSharp.Finance.Personal.Calculation.Cent>) 99990L<FSharp.Finance.Personal.Calculation.Cent>
+        
+        // Final year should have minimal book value
+        let lastYear = schedule |> List.last
+        lastYear.BookValue |> should be (lessThan 30000L<FSharp.Finance.Personal.Calculation.Cent>) // Most should be depreciated
+
+    [<Fact>]
+    let ``Total depreciation equals original basis`` () =
+        let asset = {
+            CostBasis = 500000L<FSharp.Finance.Personal.Calculation.Cent> // $5,000
+            PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+            PropertyClass = Types.AssetClass.SevenYear
+            Convention = Types.Convention.HalfYear
+        }
+        
+        let schedule = Calculations.generateSchedule asset
+        
+        let totalDepreciation = 
+            schedule 
+            |> List.sumBy (fun year -> year.DepreciationAmount)
+        
+        // Total should equal original basis (within rounding tolerance)
+        totalDepreciation |> should (equalWithin 50L<FSharp.Finance.Personal.Calculation.Cent>) asset.CostBasis
+
+    [<Fact>]
+    let ``Example computer schedule works`` () =
+        let schedule = Examples.exampleComputerSchedule ()
+        
+        schedule |> should not' (be Empty)
+        schedule.Length |> should equal 6
+        
+        let year1 = schedule |> List.head
+        year1.Year |> should equal 1
+        year1.DepreciationAmount |> should equal 200000L<FSharp.Finance.Personal.Calculation.Cent> // 20% of $10,000
+
+    [<Fact>]
+    let ``Example furniture schedule works`` () =
+        let schedule = Examples.exampleFurnitureSchedule ()
+        
+        schedule |> should not' (be Empty)
+        schedule.Length |> should equal 8 // 7-year property has 8 years
+        
+        let year1 = schedule |> List.head
+        year1.Year |> should equal 1
+        year1.DepreciationAmount |> should equal 71450L<FSharp.Finance.Personal.Calculation.Cent> // 14.29% of $5,000
+
+    [<Fact>]
+    let ``Example equipment schedule works`` () =
+        let schedule = Examples.exampleEquipmentSchedule ()
+        
+        schedule |> should not' (be Empty)
+        schedule.Length |> should equal 8
+        
+        let year1 = schedule |> List.head
+        year1.Year |> should equal 1
+        year1.DepreciationAmount |> should equal 357250L<FSharp.Finance.Personal.Calculation.Cent> // 14.29% of $25,000
+
+    [<Fact>]
+    let ``Book value decreases each year`` () =
+        let asset = {
+            CostBasis = 1500000L<FSharp.Finance.Personal.Calculation.Cent> // $15,000
+            PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+            PropertyClass = Types.AssetClass.FiveYear
+            Convention = Types.Convention.HalfYear
+        }
+        
+        let schedule = Calculations.generateSchedule asset
+        
+        // Book value should decrease each year
+        let bookValues = schedule |> List.map (fun year -> year.BookValue)
+        
+        bookValues 
+        |> List.pairwise
+        |> List.iter (fun (prev, curr) -> curr |> should be (lessThan prev))
+
+    [<Fact>]
+    let ``Accumulated depreciation increases each year`` () =
+        let asset = {
+            CostBasis = 800000L<FSharp.Finance.Personal.Calculation.Cent> // $8,000
+            PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+            PropertyClass = Types.AssetClass.ThreeYear
+            Convention = Types.Convention.HalfYear
+        }
+        
+        let schedule = Calculations.generateSchedule asset
+        
+        // Accumulated depreciation should increase each year
+        let accumulatedValues = schedule |> List.map (fun year -> year.AccumulatedDepreciation)
+        
+        accumulatedValues 
+        |> List.pairwise
+        |> List.iter (fun (prev, curr) -> curr |> should be (greaterThan prev))
+
+    [<Fact>]
+    let ``Asset classification works correctly`` () =
+        Calculations.classifyAsset "computer equipment" |> should equal Types.AssetClass.FiveYear
+        Calculations.classifyAsset "car" |> should equal Types.AssetClass.FiveYear
+        Calculations.classifyAsset "office furniture" |> should equal Types.AssetClass.SevenYear
+        Calculations.classifyAsset "manufacturing equipment" |> should equal Types.AssetClass.SevenYear
+        Calculations.classifyAsset "building" |> should equal Types.AssetClass.FifteenYear
+        Calculations.classifyAsset "general equipment" |> should equal Types.AssetClass.FiveYear // default

--- a/tests/USMacrsTests.fs
+++ b/tests/USMacrsTests.fs
@@ -3,7 +3,9 @@ namespace FSharp.Finance.Personal.Tests
 open Xunit
 open FsUnit.Xunit
 
+open FSharp.Finance.Personal.Calculation
 open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS
+open FSharp.Finance.Personal.EquipmentFinance.Depreciation.US_MACRS.Types
 
 module USMacrsTests =
 
@@ -39,7 +41,7 @@ module USMacrsTests =
     [<Fact>]
     let ``Five-year asset depreciation schedule is correct`` () =
         let asset = {
-            CostBasis = 1000000L<FSharp.Finance.Personal.Calculation.Cent> // $10,000
+            CostBasis = 10000_00L<Cent> // $10,000
             PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
             PropertyClass = Types.AssetClass.FiveYear
             Convention = Types.Convention.HalfYear
@@ -53,22 +55,22 @@ module USMacrsTests =
         let year1 = schedule |> List.head
         year1.Year |> should equal 1
         year1.DepreciationRate |> should equal 0.20m
-        year1.DepreciationAmount |> should equal 200000L<FSharp.Finance.Personal.Calculation.Cent> // $2,000
-        year1.AccumulatedDepreciation |> should equal 200000L<FSharp.Finance.Personal.Calculation.Cent>
-        year1.BookValue |> should equal 800000L<FSharp.Finance.Personal.Calculation.Cent>
+        year1.DepreciationAmount |> should equal 2000_00L<Cent> // $2,000
+        year1.AccumulatedDepreciation |> should equal 2000_00L<Cent>
+        year1.BookValue |> should equal 8000_00L<Cent>
         
         // Year 2: 32% of $10,000 = $3,200
         let year2 = schedule.[1]
         year2.Year |> should equal 2
         year2.DepreciationRate |> should equal 0.32m
-        year2.DepreciationAmount |> should equal 320000L<FSharp.Finance.Personal.Calculation.Cent> // $3,200
-        year2.AccumulatedDepreciation |> should equal 520000L<FSharp.Finance.Personal.Calculation.Cent>
-        year2.BookValue |> should equal 480000L<FSharp.Finance.Personal.Calculation.Cent>
+        year2.DepreciationAmount |> should equal 3200_00L<Cent> // $3,200
+        year2.AccumulatedDepreciation |> should equal 5200_00L<Cent>
+        year2.BookValue |> should equal 4800_00L<Cent>
 
     [<Fact>]
     let ``Three-year asset depreciation schedule is correct`` () =
         let asset = {
-            CostBasis = 300000L<FSharp.Finance.Personal.Calculation.Cent> // $3,000
+            CostBasis = 3000_00L<Cent> // $3,000
             PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
             PropertyClass = Types.AssetClass.ThreeYear
             Convention = Types.Convention.HalfYear
@@ -81,16 +83,16 @@ module USMacrsTests =
         // Year 1: 33.33% of $3,000 ≈ $999.90
         let year1 = schedule |> List.head
         year1.Year |> should equal 1
-        year1.DepreciationAmount |> should (equalWithin 100L<FSharp.Finance.Personal.Calculation.Cent>) 99990L<FSharp.Finance.Personal.Calculation.Cent>
+        year1.DepreciationAmount |> should (equalWithin 100L<Cent>) 999_90L<Cent>
         
         // Final year should have minimal book value
         let lastYear = schedule |> List.last
-        lastYear.BookValue |> should be (lessThan 30000L<FSharp.Finance.Personal.Calculation.Cent>) // Most should be depreciated
+        lastYear.BookValue |> should be (lessThan 300_00L<Cent>) // Most should be depreciated
 
     [<Fact>]
     let ``Total depreciation equals original basis`` () =
         let asset = {
-            CostBasis = 500000L<FSharp.Finance.Personal.Calculation.Cent> // $5,000
+            CostBasis = 500000L<Cent> // $5,000
             PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
             PropertyClass = Types.AssetClass.SevenYear
             Convention = Types.Convention.HalfYear
@@ -103,7 +105,7 @@ module USMacrsTests =
             |> List.sumBy (fun year -> year.DepreciationAmount)
         
         // Total should equal original basis (within rounding tolerance)
-        totalDepreciation |> should (equalWithin 50L<FSharp.Finance.Personal.Calculation.Cent>) asset.CostBasis
+        totalDepreciation |> should (equalWithin 50L<Cent>) asset.CostBasis
 
     [<Fact>]
     let ``Example computer schedule works`` () =
@@ -114,7 +116,7 @@ module USMacrsTests =
         
         let year1 = schedule |> List.head
         year1.Year |> should equal 1
-        year1.DepreciationAmount |> should equal 200000L<FSharp.Finance.Personal.Calculation.Cent> // 20% of $10,000
+        year1.DepreciationAmount |> should equal 2000_00L<Cent> // 20% of $10,000
 
     [<Fact>]
     let ``Example furniture schedule works`` () =
@@ -125,7 +127,7 @@ module USMacrsTests =
         
         let year1 = schedule |> List.head
         year1.Year |> should equal 1
-        year1.DepreciationAmount |> should equal 71450L<FSharp.Finance.Personal.Calculation.Cent> // 14.29% of $5,000
+        year1.DepreciationAmount |> should equal 714_50L<Cent> // 14.29% of $5,000
 
     [<Fact>]
     let ``Example equipment schedule works`` () =
@@ -136,12 +138,12 @@ module USMacrsTests =
         
         let year1 = schedule |> List.head
         year1.Year |> should equal 1
-        year1.DepreciationAmount |> should equal 357250L<FSharp.Finance.Personal.Calculation.Cent> // 14.29% of $25,000
+        year1.DepreciationAmount |> should equal 3572_50L<Cent> // 14.29% of $25,000
 
     [<Fact>]
     let ``Book value decreases each year`` () =
         let asset = {
-            CostBasis = 1500000L<FSharp.Finance.Personal.Calculation.Cent> // $15,000
+            CostBasis = 15000_00L<Cent> // $15,000
             PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
             PropertyClass = Types.AssetClass.FiveYear
             Convention = Types.Convention.HalfYear
@@ -159,7 +161,7 @@ module USMacrsTests =
     [<Fact>]
     let ``Accumulated depreciation increases each year`` () =
         let asset = {
-            CostBasis = 800000L<FSharp.Finance.Personal.Calculation.Cent> // $8,000
+            CostBasis = 8000_00L<Cent> // $8,000
             PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
             PropertyClass = Types.AssetClass.ThreeYear
             Convention = Types.Convention.HalfYear

--- a/tests/USMacrsTests.fs
+++ b/tests/USMacrsTests.fs
@@ -108,6 +108,33 @@ module USMacrsTests =
         totalDepreciation |> should (equalWithin 50L<Cent>) asset.CostBasis
 
     [<Fact>]
+    let ``MACRS schedule is capped at full cost basis`` () =
+        let asset = {
+            CostBasis = 100_00L<Cent>
+            PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+            PropertyClass = Types.AssetClass.ThreeYear
+            Convention = Types.Convention.HalfYear
+        }
+
+        let schedule = Calculations.generateSchedule asset
+        let lastYear = schedule |> List.last
+
+        lastYear.AccumulatedDepreciation |> should equal asset.CostBasis
+        lastYear.BookValue |> should equal 0L<Cent>
+
+    [<Fact>]
+    let ``Unsupported MACRS convention is rejected`` () =
+        let asset = {
+            CostBasis = 1000_00L<Cent>
+            PlacedInServiceDate = FSharp.Finance.Personal.DateDay.Date(2024, 1, 1)
+            PropertyClass = Types.AssetClass.FiveYear
+            Convention = Types.Convention.MidQuarter
+        }
+
+        (fun () -> Calculations.generateSchedule asset |> ignore)
+        |> should throw typeof<System.ArgumentException>
+
+    [<Fact>]
     let ``Example computer schedule works`` () =
         let schedule = Examples.exampleComputerSchedule ()
         


### PR DESCRIPTION
## Summary
Single coherent Equipment Finance feature set:
- Loans (fixed-rate, balloon support, recurring fee support)
- Leases (simplified rental schedule analytics)
- Depreciation (US MACRS simplified; UK Capital Allowances simplified)
- Shared depreciation abstractions
- Documentation for both regimes and high-level overview
- Baseline + edge test coverage
- Consistent monetary + rounding approach (`int64<Cent>`, MidpointRounding.AwayFromZero)

No public API breaking changes to existing non‑equipment modules.

## Modules Included
Namespace root: `FSharp.Finance.Personal.EquipmentFinance`

Depreciation:
- `DepreciationCommon.fs` (shared types/helpers)
- `US_MACRS.fs` (simplified MACRS Half-Year convention, limited classes)
- `UK_CapitalAllowances.fs` (AIA allocation + WDA diminishing balance 18% / 6%)

Financing:
- `Loan.fs` (EquipmentLoanTerms, schedule generator, balloon handling, fees)
- `Lease.fs` (EquipmentLeaseTerms, rental schedule generator, total cost helper)

## Depreciation Simplifications

### US MACRS (Simplified)
- Half-year convention only
- Implemented property classes: (list those present in file)
- Even intra-year allocation (monthly split or proportional annual as documented)
- No mid‑quarter convention
- No bonus depreciation (§168(k))
- No Section 179 expensing
- No luxury auto limits
- No short-year adjustments
- TODO markers for each omitted regime variant

### UK Capital Allowances (Simplified)
- AIA (Annual Investment Allowance) applied first up to configured cap for Year 1
- Remaining pool allocated to main (18%) or special (6%) pools as indicated
- Single aggregated asset assumption (no multi-asset pooled acquisitions)
- No First Year Allowances / super-deduction
- No disposal / balancing adjustments
- Termination when pool ≈ 0 or max years reached
- Allowances rounded MidpointAwayFromZero
- TODO markers: FYA, partial periods, disposal events, short period adjustments, multi-asset pooling

## Loan Scope
Implemented:
- Fixed nominal annual rate divided by payment frequency
- Balloon (residual) handling
- Recurring per-period fee
- Validation for positive principal, term, frequency
- Rounding via cent utilities

Not Implemented (TODO):
- Variable / floating rates
- Interest-only or stepped schedules
- Payment holidays
- Fee capitalization / amortized origination cost treatment
- Multi-currency

## Lease Scope
Implemented:
- Level periodic rentals with optional per-period fees
- Residual value stored informationally
- Schedule generation + total cost aggregation

Not Implemented (TODO):
- IFRS 16 / ASC 842 right-of-use accounting
- Classification logic (finance vs operating)
- Variable/index-linked payments
- Residual value guarantees & purchase options
- Re-measurement events

## Tests Added
- Simple Depreciation (straight-line and declining-balance)
- Loan:
  - Balloon residual near expected
  - Invalid parameter guards (negative principal/term/frequency, balloon > principal)
  - Principal portions + balloon ≈ original principal (rounding tolerance)
- Lease:
  - Schedule length correctness
  - Total cost aggregation
  - Residual value independence of rental math
- US MACRS:
  - Depreciation sum ≈ cost basis (tolerance)
  - Non-negative declining remaining basis
- UK Capital Allowances:
  - AIA total elimination case
  - Partial AIA then WDA year 2 diminishing balance
  - Final tiny residual clearance
- Rounding edge test (midpoint behavior)

## Documentation Changes
Added / Updated:
- `docs/equipmentFinanceOverview.md` (Loans, Leases, US & UK depreciation)
- `docs/equipmentFinanceUsMacrs.md` (simplifications + TODO)
- `docs/equipmentFinanceUk.md` (simplifications + TODO)
- `docs/BUSINESS_CASES_INDEX.md` (marks Equipment Finance as implemented, notes “simplified”)
- README: concise Equipment Finance section linking these docs

All docs emphasize: analytical-only; not financial / tax / accounting advice.

## Rounding & Monetary Consistency
- All monetary values: `int64<Cent>`
- Derived values use `Cent.fromDecimalCent MidpointRounding.AwayFromZero`
- Tests assert invariants within ≤ 1 cent tolerance where appropriate

## Backwards Compatibility
- Additive only; no changes to existing non-equipment modules
- No version bump (per instructions). Merge conflicts (if any) resolved favoring retention of existing main content plus ordered new includes

## Next Steps (Proposed Roadmap)
1. US MACRS: mid-quarter, bonus, Section 179, luxury auto limits
2. UK: FYA / super-deduction historic support, disposal adjustments
3. Multi-asset pooling & asset-level tracking
4. Lease accounting (IFRS 16 / ASC 842) with PV & remeasurement logic
5. Variable / floating loan rates & interest-only phases
6. IRR / XIRR integration for comparative analytics
7. After-tax scenario engine (depreciation + financing + salvage)
8. Multi-currency extension
9. Performance profiling & potential lazy schedules
10. Lease vs Buy integrated NPV comparer

## Validation Checklist
- [x] Clean `dotnet build` succeeds
- [x] `dotnet test` passes

## License / Disclaimer
Analytical-only computations. Not tax, legal, accounting, or financial advice. Users must verify applicability and compliance independently.
