### PR TITLE
Fix schedule generation, APR calculations, and rebate handling

### DIFF
--- a/docs/interestActuarial.fsx
+++ b/docs/interestActuarial.fsx
@@ -234,7 +234,7 @@ The final payment is adjusted (`cref:M:FSharp.Finance.Personal.Scheduling.adjust
 
 let items =
     basicItems
-    |> adjustFinalPayment finalScheduledPaymentDay bp.ScheduleConfig.IsAutoGenerateSchedule
+    |> adjustFinalPayment bp finalScheduledPaymentDay bp.ScheduleConfig.IsAutoGenerateSchedule
 
 (*** hide ***)
 {

--- a/docs/interestAddOn.fsx
+++ b/docs/interestAddOn.fsx
@@ -238,7 +238,7 @@ let isAutoGenerateSchedule = bp.ScheduleConfig.IsAutoGenerateSchedule
 
 let items =
     basicItems'
-    |> adjustFinalPayment finalScheduledPaymentDay isAutoGenerateSchedule
+    |> adjustFinalPayment bp finalScheduledPaymentDay isAutoGenerateSchedule
 
 (*** hide ***)
 {

--- a/src/Amortisation.fs
+++ b/src/Amortisation.fs
@@ -831,6 +831,10 @@ module Amortisation =
     /// calculates an amortisation schedule detailing how elements (principal, fee, interest and charges) are paid off over time
     let internal calculate (p: Parameters) initialStats (appliedPayments: Map<int<OffsetDay>, AppliedPayment>) =
 
+        // guard against empty maps (e.g. a custom schedule with no payments), as no meaningful schedule can be generated
+        if Map.isEmpty appliedPayments then
+            failwith "Cannot amortise an empty payment schedule"
+
         let evaluationDay = (p.Basic.EvaluationDate - p.Basic.StartDate).Days * 1<OffsetDay>
 
         // get the decimal initial interest balance (interest is generally calculated as a decimal until concretised as an interest portion, at which point it is rounded to an integer)

--- a/src/Amortisation.fs
+++ b/src/Amortisation.fs
@@ -559,6 +559,12 @@ module Amortisation =
                 OriginalScheduledPaymentValue = ap.ScheduledPayment.Original.Value
             |})
 
+        // if there are no original scheduled payments (e.g. the schedule consists entirely of rescheduled payments),
+        // there is no original-schedule basis on which to calculate a statutory rebate
+        if Array.isEmpty originalScheduledPayments then
+            0L<Cent>
+        else
+
         let unitPeriod =
             match bp.ScheduleConfig with
             | AutoGenerateSchedule ags -> UnitPeriod.Config.unitPeriod ags.UnitPeriodConfig
@@ -579,8 +585,13 @@ module Amortisation =
         let previousScheduledPaymentDate =
             originalScheduledPayments
             |> Array.filter (fun osp -> osp.OffsetDay <= appliedPaymentDay)
-            |> Array.last
-            |> _.OffsetDay
+            |> Array.tryLast
+            |> Option.map _.OffsetDay
+            // if settlement occurs before the first scheduled payment day, the first settlement period runs from the
+            // date of the agreement itself: the CCA 2004 regulation 4(1) formula measures periods between repayment
+            // dates, with the part-period at the point of settlement measured from the latest repayment date or, where
+            // none has yet fallen due, from the start of the agreement, so fall back to day 0 (the advance date)
+            |> Option.defaultValue 0<OffsetDay>
 
         let numerator = appliedPaymentDay - previousScheduledPaymentDate |> int
         let denominator = UnitPeriod.roughLength unitPeriod
@@ -1007,12 +1018,24 @@ module Amortisation =
                     currentDay
                     totals'.CumulativeFee
 
+            // determine the rebate that would actually be applied on settlement: for UK FCA-regulated agreements, if the
+            // statutory rebate is higher than the fee rebate calculated above, the statutory rebate applies; this must be
+            // determined before the settlement figure is composed so that the figure and the fee apportionment are based
+            // on the same rebate
+            let applicableFeeRebate =
+                match p.Basic.InterestConfig.AprMethod with
+                | Apr.CalculationMethod.UnitedKingdom _ when feeRebateIfSettled > 0L<Cent> ->
+                    calculateStatutoryFeeRebate p.Basic appliedPayments initialStats currentDay window
+                    |> max feeRebateIfSettled
+                    |> min feeTotal
+                | _ -> feeRebateIfSettled
+
             // refine the settlement figure depending on the interest method
             let generatedSettlementPayment' =
                 match p.Basic.InterestConfig.Method with
                 | Interest.Method.AddOn -> generatedSettlementPayment
                 | _ ->
-                    previous.PrincipalBalance + previous.FeeBalance - feeRebateIfSettled
+                    previous.PrincipalBalance + previous.FeeBalance - applicableFeeRebate
                     + interestPortionL'
                     + chargesPortion
 
@@ -1022,16 +1045,7 @@ module Amortisation =
                     current.GeneratedPayment.IsToBeGenerated
                     || feePortion > 0L<Cent> && generatedSettlementPayment' <= netEffect
                 then
-                    let feeRebate' =
-                        match p.Basic.InterestConfig.AprMethod with
-                        | Apr.CalculationMethod.UnitedKingdom _ when feeRebateIfSettled > 0L<Cent> ->
-                            // if the statutory rebate is higher than the fee rebate calculated above, use the higher figure
-                            calculateStatutoryFeeRebate p.Basic appliedPayments initialStats currentDay window
-                            |> max feeRebateIfSettled
-                            |> min feeTotal
-                        | _ -> feeRebateIfSettled
-
-                    max 0L<Cent> (previous.FeeBalance - feeRebate'), feeRebate'
+                    max 0L<Cent> (previous.FeeBalance - applicableFeeRebate), applicableFeeRebate
                 else
                     sign feePortion, 0L<Cent>
 
@@ -1175,14 +1189,17 @@ module Amortisation =
                     ActuarialInterest = cappedActuarialInterestM
                     NewInterest = cappedNewInterestM'
                     NewCharges = incurredCharges
+                    // where the fee rebate exceeds the fee balance (possible e.g. for UK statutory rebates), the fee
+                    // portion is floored at zero and the excess rebate reduces the principal portion instead, so the
+                    // portions still sum to the settlement figure without any negative fee portion
                     PrincipalPortion =
                         if isSettlement then
-                            previous.PrincipalBalance
+                            previous.PrincipalBalance - max 0L<Cent> (feeRebate - previous.FeeBalance)
                         else
                             principalPortion'
                     FeePortion =
                         if isSettlement then
-                            previous.FeeBalance - feeRebate
+                            max 0L<Cent> (previous.FeeBalance - feeRebate)
                         else
                             feePortion'
                     InterestPortion = interestPortionL'

--- a/src/Amortisation.fs
+++ b/src/Amortisation.fs
@@ -995,14 +995,40 @@ module Amortisation =
                     (Cent.toDecimalCent totals.CumulativeInterestPortions)
                 |> Cent.fromDecimalCent interestRounding
 
-            // determine how much of the net effect can be apportioned and whether any immediate adjustments need to be made to the scheduled payment due to charges and interest, depending on settings
-            let assignable, scheduledPaymentAdjustment =
-                if netEffect = 0L<Cent> then
-                    0L<Cent>, 0L<Cent>
+            // determine whether any immediate adjustments need to be made to the scheduled payment due to charges and interest, depending on settings:
+            // under AddChargesAndInterest, any charges and interest are added to the scheduled payment itself, increasing the amount due
+            // (and collected, for payments not yet made) on the day rather than being amortised later, so that the balance can close at
+            // the end of the schedule
+            let scheduledPaymentAdjustment =
+                match p.Advanced.PaymentConfig.ScheduledPaymentOption with
+                | AddChargesAndInterest when netEffect > 0L<Cent> && paymentDue > 0L<Cent> ->
+                    // the adjusted payment due should still never exceed the total outstanding (balances plus accrued interest and charges)
+                    let cappedPaymentDue =
+                        paymentDue + chargesPortion + interestPortionL'
+                        |> min (
+                            previous.PrincipalBalance + previous.FeeBalance
+                            + interestPortionL'
+                            + chargesPortion
+                        )
+
+                    max 0L<Cent> (cappedPaymentDue - paymentDue)
+                | _ -> 0L<Cent>
+
+            // the adjustment increases the payment due and, for payments not yet due (which are assumed to be paid in full), the net effect
+            let paymentDue = paymentDue + scheduledPaymentAdjustment
+
+            let netEffect =
+                if currentDay > evaluationDay then
+                    netEffect + scheduledPaymentAdjustment
                 else
-                    match p.Advanced.PaymentConfig.ScheduledPaymentOption with
-                    | AsScheduled -> sign netEffect - sign chargesPortion - sign interestPortionL', 0L<Cent>
-                    | AddChargesAndInterest -> sign netEffect, sign chargesPortion - sign interestPortionL'
+                    netEffect
+
+            // determine how much of the net effect can be apportioned to the fee and principal balances
+            let assignable =
+                if netEffect = 0L<Cent> then
+                    0L<Cent>
+                else
+                    sign netEffect - sign chargesPortion - sign interestPortionL'
 
             let scheduledPayment = {
                 current.ScheduledPayment with

--- a/src/Amortisation.fs
+++ b/src/Amortisation.fs
@@ -931,7 +931,22 @@ module Amortisation =
 
             let newChargesTotal, incurredCharges =
                 if paymentDue = 0L<Cent> then
-                    0L<Cent>, [||]
+                    // when nothing is due on the day, charges relating to non-payment of an amount due (e.g. late-payment
+                    // charges) are suppressed, but charges incurred by failed payments (e.g. insufficient-funds charges
+                    // on a failed retry on a non-schedule day) still apply
+                    let failedPaymentChargeTypes =
+                        current.ActualPayments
+                        |> Array.choose (fun ap ->
+                            match ap.ActualPaymentStatus with
+                            | ActualPaymentStatus.Failed(_, ValueSome chargeType) -> Some chargeType
+                            | _ -> None
+                        )
+
+                    let failedPaymentCharges =
+                        current.AppliedCharges
+                        |> Array.filter (fun ac -> failedPaymentChargeTypes |> Array.contains ac.ChargeType)
+
+                    failedPaymentCharges |> Array.sumBy _.Total, failedPaymentCharges
                 else
                     current.AppliedCharges |> Array.sumBy _.Total, current.AppliedCharges
 

--- a/src/AppliedPayment.fs
+++ b/src/AppliedPayment.fs
@@ -209,6 +209,9 @@ module AppliedPayment =
                                 | 0L<Cent>, cpt when cpt < 0L<Cent> -> cpt, Refunded
                                 // no payment due, but a payment made
                                 | 0L<Cent>, cpt -> cpt, ExtraPayment
+                                // a payment due (now or previously), but a refund issued
+                                | spt, cpt when spt > 0L<Cent> && cpt < 0L<Cent> && offsetDay <= evaluationDay ->
+                                    cpt, Refunded
                                 // a payment due on or before the day
                                 | spt, cpt when
                                     cpt < spt
@@ -220,9 +223,11 @@ module AppliedPayment =
                                     // settlement requested on a future day
                                     | SettlementDay.SettlementOnEvaluationDay when evaluationDay > offsetDay ->
                                         0L<Cent>, PaymentDue
-                                    // settlement requested on the day, requiring a generated payment to be calculated (calculation deferred until amortisation schedule is generated)
+                                    // settlement requested on the day: any confirmed partial payment takes net effect so
+                                    // that it is deducted from the generated settlement figure (calculation of the generated
+                                    // payment itself is deferred until the amortisation schedule is generated)
                                     | SettlementDay.SettlementOnEvaluationDay when evaluationDay = offsetDay ->
-                                        0L<Cent>, Generated
+                                        cpt, Generated
                                     // no settlement on day, or statement requested
                                     | _ -> spt, PaymentDue
                                 // a payment due on a future day

--- a/src/Apr.fs
+++ b/src/Apr.fs
@@ -50,12 +50,13 @@ module Apr =
         Value: int64<Cent>
     }
 
-    /// an approximation of the unit-period equivalent of the APR
+    /// an approximation of the unit-period equivalent of the APR, expressed as a decimal rate (not a percentage),
+    /// used as the initial guess for the solver
     let roughUnitPeriodRate principal interestTotal paymentCount =
         if principal = 0m then
             0m
         else
-            2m * interestTotal / (principal * (paymentCount + 1m)) * 100m
+            2m * interestTotal / (principal * (paymentCount + 1m))
 
 
     /// calculates the APR (note that as of 2025-05-08 the EU and UK calculation methods are aligned)
@@ -88,12 +89,15 @@ module Apr =
                 let calc transfers unitPeriodRate =
                     transfers
                     |> Array.sumBy (fun (amount, years) ->
-                        let divisor = 1m + unitPeriodRate |> powm years
+                        try // rates near -1 with long-dated payments produce tiny divisors whose quotients overflow decimal, so treat these as zero (as in the US calculation)
+                            let divisor = 1m + unitPeriodRate |> powm years
 
-                        if Double.IsNaN divisor || divisor = 0. then
+                            if Double.IsNaN divisor || divisor = 0. then
+                                0m
+                            else
+                                amount |> Cent.toDecimal |> (fun a -> double a / divisor |> decimal)
+                        with _ ->
                             0m
-                        else
-                            amount |> Cent.toDecimal |> (fun a -> double a / divisor |> decimal)
                     )
 
                 let generator unitPeriodRate =
@@ -137,14 +141,13 @@ module Apr =
         /// shall be determined by dividing the number of days between the 2 given dates by the number of days per unit-period. If the
         /// unit-period is a day, the number of unit-periods per year shall be 365. [...]
         let dailyUnitPeriods termStart transfers =
-            let transferDates = transfers |> Array.map _.TransferDate
-            let offset = daysBetween termStart (transferDates |> Array.head)
-
             transfers
-            |> Array.mapi (fun i t ->
+            |> Array.map (fun t ->
                 t,
                 {
-                    Quotient = i + offset
+                    // the number of unit-periods is the actual number of days from the start of the term to the transfer date,
+                    // rather than an index-based count that would assume consecutive daily transfers
+                    Quotient = daysBetween termStart t.TransferDate
                     Remainder = 0m
                 }
             )
@@ -254,18 +257,19 @@ module Apr =
         /// 52 divided by the number of weeks per unit-period.
         let weeklyUnitPeriods multiple termStart transfers =
             let multiple = Math.Max(1, multiple)
-            let transferDates = transfers |> Array.map _.TransferDate
-
-            let dr =
-                decimal (daysBetween termStart (transferDates |> Array.head))
-                / (7m * decimal multiple)
-                |> fun d -> divRem d 1m
+            let daysPerUnitPeriod = 7m * decimal multiple
 
             transfers
-            |> Array.mapi (fun i t ->
+            |> Array.map (fun t ->
+                // divide the actual number of days from the start of the term to the transfer date by the number of days
+                // per unit-period, rather than assuming transfers fall on consecutive unit-period boundaries
+                let dr =
+                    decimal (daysBetween termStart t.TransferDate) / daysPerUnitPeriod
+                    |> fun d -> divRem d 1m
+
                 t,
                 {
-                    Quotient = dr.Quotient + i
+                    Quotient = dr.Quotient
                     Remainder = dr.Remainder
                 }
             )
@@ -302,21 +306,38 @@ module Apr =
                 else
                     let paymentTotal = payments |> Array.sumBy (_.Value >> Cent.toDecimal)
 
+                    let advanceDates = advances |> Array.map _.TransferDate
+                    let paymentDates = payments |> Array.map _.TransferDate
+
+                    let term =
+                        UnitPeriod.transactionTerm
+                            consummationDate
+                            firstFinanceChargeEarnedDate
+                            (paymentDates |> Array.last)
+                            (advanceDates |> Array.last)
+
                     if advanceTotal = paymentTotal then
                         Solution.Found(0m, 0, 0m)
+                    elif term.Duration = 0<DurationDay> then
+                        // all transfers fall on the term start date, so there is no time dimension over which to compute a rate
+                        Solution.Impossible
                     else
-                        let advanceDates = advances |> Array.map _.TransferDate
-                        let paymentDates = payments |> Array.map _.TransferDate
+                        let unitPeriodsPerYear, unitPeriodMap =
+                            // (b)(5)(vi)/(vii): in a single advance, single payment transaction in which the term is less than
+                            // a year, the unit-period is the term itself, so the number of unit-periods in the term is 1, and
+                            // the number of unit-periods per year is 12 divided by the number of months in the term if the term
+                            // is equal to a whole number of months, or 365 divided by the number of days in the term otherwise
+                            if Array.length advances = 1 && Array.length payments = 1 && int term.Duration < 365 then
+                                let unitPeriodsPerYear =
+                                    match [| 1..11 |] |> Array.tryFind (fun m -> term.Start.AddMonths m = term.End) with
+                                    | Some months -> 12m / decimal months
+                                    | None -> 365m / decimal (int term.Duration)
 
-                        let term =
-                            UnitPeriod.transactionTerm
-                                consummationDate
-                                firstFinanceChargeEarnedDate
-                                (paymentDates |> Array.last)
-                                (advanceDates |> Array.last)
+                                unitPeriodsPerYear, singleUnitPeriod
+                            else
+                                let unitPeriod = UnitPeriod.nearest term advanceDates paymentDates
+                                UnitPeriod.numberPerYear unitPeriod, mapUnitPeriods unitPeriod
 
-                        let unitPeriod = UnitPeriod.nearest term advanceDates paymentDates
-                        let unitPeriodsPerYear = UnitPeriod.numberPerYear unitPeriod
                         let paymentCount = payments |> Array.length |> decimal
                         let interestTotal = paymentTotal - advanceTotal
 
@@ -327,7 +348,7 @@ module Apr =
                             let eq = [| advances[0].Value, 0m, 0 |]
 
                             let ft =
-                                mapUnitPeriods unitPeriod term.Start payments
+                                unitPeriodMap term.Start payments
                                 |> Array.map (fun (tr, dr) ->
                                     let f = dr.Remainder //The fraction of a unit-period in the time interval from the beginning of the term of the transaction to the jth payment.
                                     let t = dr.Quotient //The number of full unit-periods from the beginning of the term of the transaction to the jth payment.
@@ -397,15 +418,19 @@ module Apr =
             | _ -> 0
 
         match aprSolution with
-        | Solution.Found(apr, _, _)
-        | Solution.IterationLimitReached(apr, _, _) -> Decimal.Round(apr, precision) |> Percent.fromDecimal
+        | Solution.Found(apr, _, _) -> Decimal.Round(apr, precision) |> Percent.fromDecimal
+        // the Newton-Raphson solver only reports the iteration limit when the residual is still outside the tolerance,
+        // so the partial solution is unreliable and must not be reported as if it were a valid APR
         | _ -> Percent 0m
 
     /// calculates the APR rate for the specified unit-period as per UK regulation
     let ukUnitPeriodRate unitPeriod apr =
+        let unitPeriodsPerYear = UnitPeriod.numberPerYear unitPeriod
+
+        if unitPeriodsPerYear = 0m then
+            failwith $"Invalid unit period {unitPeriod}: it has zero unit-periods per year"
+
         apr
         |> Percent.toDecimal
-        |> fun m ->
-            (((1m + m) |> powm (1m / UnitPeriod.numberPerYear unitPeriod) |> decimal) - 1m)
-            * 100m
+        |> fun m -> (((1m + m) |> powm (1m / unitPeriodsPerYear) |> decimal) - 1m) * 100m
         |> Percent

--- a/src/Calculation.fs
+++ b/src/Calculation.fs
@@ -291,6 +291,43 @@ module Calculation =
         let solveBisection generator (iterationLimit: uint) initialGuess targetTolerance toleranceSteps =
             let initialLowerBound, initialUpperBound =
                 initialGuess * 0.75m, initialGuess * 1.25m
+            // determine the target range for a given tolerance
+            let toleranceRange tolerance =
+                match targetTolerance with
+                | BelowZero -> -tolerance, 0m
+                | AroundZero -> -tolerance, tolerance
+                | AboveZero -> 0m, tolerance
+            // the initial guess is only an estimate, so the root may well lie outside the initial bounds: as the generator function is
+            // expected to be decreasing, the root is only guaranteed to be bracketed when the generated value at the lower bound is above
+            // the target range and the generated value at the upper bound is below it; if not, expand the bounds geometrically (doubling
+            // the width each round, with the bounds limited to zero below and four times the initial guess above) for a few rounds
+            let maxUpperBound = initialGuess * 4m
+
+            let rec expandBounds expansionRounds lowerBound upperBound =
+                if expansionRounds = 0 then
+                    lowerBound, upperBound
+                else
+                    let lowerTolerance, upperTolerance = toleranceRange toleranceSteps.MinTolerance
+                    let expandLower = (generator lowerBound |> fst) < lowerTolerance && lowerBound > 0m
+
+                    let expandUpper =
+                        (generator upperBound |> fst) > upperTolerance && upperBound < maxUpperBound
+
+                    if not expandLower && not expandUpper then
+                        lowerBound, upperBound
+                    else
+                        let width = upperBound - lowerBound
+
+                        let newLowerBound =
+                            if expandLower then max 0m (lowerBound - width) else lowerBound
+
+                        let newUpperBound =
+                            if expandUpper then
+                                min maxUpperBound (upperBound + width)
+                            else
+                                upperBound
+
+                        expandBounds (expansionRounds - 1) newLowerBound newUpperBound
             // recursively iterate through possible solutions
             let rec loop iteration lowerBound upperBound tolerance =
                 // find the midpoint of the bounds
@@ -300,11 +337,7 @@ module Calculation =
                     // generate a result using the new figure
                     let candidate, relevantValue = generator midpoint
                     // determine the target range
-                    let lowerTolerance, upperTolerance =
-                        match targetTolerance with
-                        | BelowZero -> -tolerance, 0m
-                        | AroundZero -> -tolerance, tolerance
-                        | AboveZero -> 0m, tolerance
+                    let lowerTolerance, upperTolerance = toleranceRange tolerance
                     // if the solution is within target range, return the value
                     if candidate >= lowerTolerance && candidate <= upperTolerance then
                         Solution.Found(relevantValue, iteration, tolerance)
@@ -324,8 +357,10 @@ module Calculation =
 
                     let newLowerBound, newUpperBound = midpoint - newTolerance, midpoint + newTolerance
                     loop 0 newLowerBound newUpperBound newTolerance
+            // ensure the root is bracketed by the bounds where possible
+            let lowerBound, upperBound = expandBounds 8 initialLowerBound initialUpperBound
             // start the first iteration
-            loop 0 initialLowerBound initialUpperBound toleranceSteps.MinTolerance
+            loop 0 lowerBound upperBound toleranceSteps.MinTolerance
 
         /// use the Newton-Raphson method to find the solution (particularly suitable for calculating the APR)
         let solveNewtonRaphson f (iterationLimit: uint) initialGuess tolerance =

--- a/src/Calculation.fs
+++ b/src/Calculation.fs
@@ -337,17 +337,24 @@ module Calculation =
             let rec loop x iteration =
                 // until the iteration limit is reached
                 if iteration <= int iterationLimit then
-                    // get the function value of `x`
-                    let fx = f x
+                    // get the function value of `x`, guarding against decimal overflow at extreme guess values
+                    match (try ValueSome(f x) with :? OverflowException -> ValueNone) with
                     // if the function value is within the tolerance, return the solution
-                    if abs fx < tolerance then
-                        Solution.Found(x, iteration, tolerance)
+                    | ValueSome fx when abs fx < tolerance -> Solution.Found(x, iteration, tolerance)
                     // otherwise, iterate again using an improved guess
-                    else
-                        // get the derivative of the function value of `x`
-                        let f'x = derivative f x 1e-5m
-                        // loop by using the derivative to generate a better guess value
-                        loop (if f'x = 0m then 0m else x - fx / f'x) (iteration + 1)
+                    | ValueSome fx ->
+                        let x' =
+                            try
+                                // get the derivative of the function value of `x` and use it to generate a better guess value
+                                let f'x = derivative f x (max 1e-5m (abs x * 1e-5m))
+                                if f'x = 0m then 0m else x - fx / f'x
+                            with :? OverflowException ->
+                                // treat an overflow as a failed step and dampen the guess instead
+                                x / 2m
+
+                        loop x' (iteration + 1)
+                    // if the function value cannot even be evaluated, dampen the guess and try again
+                    | ValueNone -> loop (x / 2m) (iteration + 1)
                 // if the iteration limit is reached without a solution, return the latest value with a warning
                 else
                     Solution.IterationLimitReached(x, iteration, tolerance)

--- a/src/Refinancing.fs
+++ b/src/Refinancing.fs
@@ -147,13 +147,39 @@ module Refinancing =
         let newPaymentSchedule =
             match rp.PaymentSchedule with
             | AutoGenerateSchedule _ ->
+                // the reschedule day is the evaluation day, i.e. the day on which the rescheduling takes place
+                let rescheduleDay = p.Basic.EvaluationDate |> OffsetDay.fromDate p.Basic.StartDate
+                // determine the balance outstanding on the reschedule day, including the full fee balance, as the fee is rescheduled rather than settled
+                let outstandingBalance =
+                    match quote.QuoteResult with
+                    | PaymentQuote pq ->
+                        pq.Apportionment.PrincipalPortion
+                        + pq.Apportionment.FeePortion
+                        + pq.FeeRebateIfSettled
+                        + pq.Apportionment.InterestPortion
+                        + pq.Apportionment.ChargesPortion
+                    | _ -> failwith "Unable to obtain quote for rescheduling"
+                // generate the new payment plan against the outstanding balance, starting on the reschedule day, then
+                // re-base the plan onto the original schedule's day axis as rescheduled payments so that any original
+                // payments due on or after the reschedule day are cancelled when the schedules are merged
                 calculateBasicSchedule {
                     p.Basic with
+                        StartDate = p.Basic.EvaluationDate
+                        Principal = outstandingBalance
+                        FeeConfig = ValueNone
                         ScheduleConfig = rp.PaymentSchedule
                 }
                 |> _.Items
                 |> Array.filter (_.ScheduledPayment >> ScheduledPayment.isSome)
-                |> Array.map (fun si -> si.Day, si.ScheduledPayment)
+                |> Array.map (fun si ->
+                    si.Day + rescheduleDay,
+                    ScheduledPayment.quick
+                        ValueNone
+                        (ValueSome {
+                            Value = ScheduledPayment.total si.ScheduledPayment
+                            RescheduleDay = rescheduleDay
+                        })
+                )
             | FixedSchedules fixedSchedules ->
                 fixedSchedules
                 |> Array.collect (fun fs ->
@@ -295,7 +321,18 @@ module Refinancing =
                                     match fc.SettlementRebate with
                                     | Fee.SettlementRebate.ProRata
                                     | Fee.SettlementRebate.ProRataRescheduled _ ->
-                                        Fee.SettlementRebate.ProRataRescheduled rp.OriginalFinalPaymentDay
+                                        // re-base the original final payment day onto the new schedule's day axis, whose
+                                        // day 0 is the rollover day rather than the original start date
+                                        let rolloverDay =
+                                            p.Basic.EvaluationDate |> OffsetDay.fromDate p.Basic.StartDate
+
+                                        let remainingRebateDays = rp.OriginalFinalPaymentDay - rolloverDay
+
+                                        if remainingRebateDays <= 0<OffsetDay> then
+                                            // the original rebate window has already expired, so no rebate is due
+                                            Fee.SettlementRebate.Zero
+                                        else
+                                            Fee.SettlementRebate.ProRataRescheduled remainingRebateDays
                                     | _ as fsr -> fsr
                     })
                 Advanced.SettlementDay = SettlementDay.NoSettlement

--- a/src/Scheduling.fs
+++ b/src/Scheduling.fs
@@ -1058,6 +1058,9 @@ module Scheduling =
                         * dailyInterestRate
                         * decimal finalScheduledPaymentDay
                         * Fraction.toDecimal (Fraction.Simple(2, 3))
+                        // the schedule itself caps the accruing interest, so cap the estimate in the same way,
+                        // otherwise the estimated payment value could be far higher than the true value
+                        |> Interest.Cap.cappedAddedValue bp.InterestConfig.Cap.TotalAmount bp.Principal 0m<Cent>
                 // determines the payment value and generates the schedule iteratively based on that
                 let generator = generatePaymentValue bp paymentDays initialBasicItem
                 let iterationLimit = 100u
@@ -1067,31 +1070,68 @@ module Scheduling =
                     |> Cent.toDecimalCent
                     |> decimal
 
-                match
+                let solution =
                     Array.solveBisection
                         generator
                         iterationLimit
                         roughPayment
                         (LevelPaymentOption.toTargetTolerance bp.PaymentConfig.LevelPaymentOption)
                         toleranceSteps
-                with
-                | Solution.Found(paymentValue, _, _) ->
-                    let paymentMap' =
-                        paymentMap
-                        |> Map.map (fun _ sp -> {
-                            sp with
-                                Original = sp.Original |> ValueOption.map (fun _ -> paymentValue |> Cent.fromDecimal)
-                        })
 
-                    generateItems paymentMap'
-                | _ -> [||]
+                let paymentValue =
+                    match solution with
+                    | Solution.Found(paymentValue, _, _) -> paymentValue
+                    | Solution.IterationLimitReached(partialSolution, iterations, maxTolerance) ->
+                        // when interest rates are high and schedules are long, a one-cent change in the payment value can change
+                        // the final principal balance by more than the maximum solver tolerance, meaning that no payment value at
+                        // all satisfies the tolerance; the partial solution is the solver's best approximation of the root, so
+                        // test the rounded payment values just around it and accept the best one consistent with the level-payment
+                        // option (any overpayment is absorbed later by adjusting the final payment, which may shorten the schedule)
+                        let candidates =
+                            [| -4m .. 4m |]
+                            |> Array.map (fun offset -> generator (System.Decimal.Round partialSolution + offset))
+                            |> Array.distinctBy snd
+
+                        let fallback =
+                            match bp.PaymentConfig.LevelPaymentOption with
+                            | LowerFinalPayment ->
+                                candidates
+                                |> Array.filter (fun (balance, _) -> balance <= 0m)
+                                |> Array.sortBy snd
+                                |> Array.tryHead
+                            | HigherFinalPayment ->
+                                candidates
+                                |> Array.filter (fun (balance, _) -> balance >= 0m)
+                                |> Array.sortByDescending snd
+                                |> Array.tryHead
+                            | SimilarFinalPayment ->
+                                candidates |> Array.sortBy (fun (balance, _) -> abs balance) |> Array.tryHead
+
+                        match fallback with
+                        | Some(_, paymentValue) -> paymentValue
+                        | None ->
+                            failwith
+                                $"Unable to calculate basic schedule: the payment solver hit its iteration limit before finding a solution (iterations: {iterations}, max tolerance: {maxTolerance}, best approximation: {partialSolution}) for principal {bp.Principal}, payment count {paymentCount}, rough payment {roughPayment}, final payment day {finalScheduledPaymentDay}"
+                    | Solution.Impossible ->
+                        failwith
+                            $"Unable to calculate basic schedule: the payment solver could not find a solution for principal {bp.Principal}, payment count {paymentCount}, rough payment {roughPayment}, final payment day {finalScheduledPaymentDay}"
+
+                let paymentMap' =
+                    paymentMap
+                    |> Map.map (fun _ sp -> {
+                        sp with
+                            Original = sp.Original |> ValueOption.map (fun _ -> paymentValue |> Cent.fromDecimal)
+                    })
+
+                generateItems paymentMap'
             | FixedSchedules _
             | CustomSchedule _ ->
                 // the days and payment values are known so the schedule can be generated directly
                 generateItems paymentMap
         // fail if the schedule is empty
         if Array.isEmpty basicItems then
-            failwith "Unable to calculate basic schedule"
+            failwith
+                $"Unable to calculate basic schedule: generating the schedule items produced an empty schedule for principal {bp.Principal}, payment count {paymentCount}, final payment day {finalScheduledPaymentDay}"
         else
             // for the add-on interest method, now the schedule days and payment values are known, iterate through the schedule until the final principal balance is zero
             // note: this step is required because the initial interest balance is non-zero, meaning that any payments are apportioned to interest first, meaning that

--- a/src/Scheduling.fs
+++ b/src/Scheduling.fs
@@ -1017,6 +1017,11 @@ module Scheduling =
             paymentDays |> Array.tryLast |> Option.defaultValue 0<OffsetDay>
         // get the payment count for use in further calculations
         let paymentCount = paymentDays |> Array.length
+        // fail early with a descriptive message if the schedule config yields no payment days at all, as no meaningful schedule
+        // can be generated (and the add-on interest method would otherwise fail while equalising the interest)
+        if paymentCount = 0 then
+            failwith
+                $"Unable to calculate basic schedule: the schedule config yields no payment days. Note that fixed and auto-generated schedules whose unit-period config starts before the loan start date ({bp.StartDate.Html}) are silently ignored, so check that the unit-period config start date is not earlier than the loan start date."
         // calculate the total fee value for the entire schedule
         let feeTotal = Fee.total bp.FeeConfig bp.Principal
         // get the initial interest balance

--- a/src/Scheduling.fs
+++ b/src/Scheduling.fs
@@ -942,44 +942,69 @@ module Scheduling =
         let principalBalance = decimal schedule.PrincipalBalance
         principalBalance, ScheduledPayment.total schedule.ScheduledPayment |> Cent.toDecimal
 
-    /// handle any principal balance overpayment (due to rounding) on the final payment of a schedule
-    let adjustFinalPayment finalScheduledPaymentDay isAutoGenerateSchedule basicItems =
-        basicItems
-        |> Array.map (fun bi ->
-            if bi.Day = finalScheduledPaymentDay && isAutoGenerateSchedule then
-                let adjustedPayment =
-                    bi.ScheduledPayment
-                    |> fun sp -> {
-                        bi.ScheduledPayment with
-                            Original =
-                                if sp.Rescheduled.IsNone then
-                                    sp.Original |> ValueOption.map (fun o -> o + bi.PrincipalBalance)
-                                else
-                                    sp.Original
-                            Rescheduled =
-                                if sp.Rescheduled.IsSome then
-                                    sp.Rescheduled
-                                    |> ValueOption.map (fun r -> {
-                                        r with
-                                            Value = r.Value + bi.PrincipalBalance
-                                    })
-                                else
-                                    sp.Rescheduled
-                    }
+    /// handle any principal balance underpayment or overpayment (due to rounding) on the final payment of a schedule
+    let adjustFinalPayment bp finalScheduledPaymentDay isAutoGenerateSchedule (basicItems: BasicItem array) =
+        if not isAutoGenerateSchedule || Array.length basicItems < 2 then
+            basicItems
+        else
+            // apply an adjustment to the original or rescheduled value of a scheduled payment as appropriate
+            let adjustPayment adjustment sp = {
+                sp with
+                    Original =
+                        if sp.Rescheduled.IsNone then
+                            sp.Original |> ValueOption.map (fun o -> o + adjustment)
+                        else
+                            sp.Original
+                    Rescheduled =
+                        sp.Rescheduled
+                        |> ValueOption.map (fun r -> { r with Value = r.Value + adjustment })
+            }
+            // regenerate the schedule from the seed item (the first item produced by `Array.scan`, which has no scheduled
+            // payment and is therefore left untouched, even when it shares day 0 with a payment), adjusting the payments so
+            // that the principal balance cannot go negative and no scheduled payment can be negative: the final payment is
+            // adjusted to close the balance exactly, while any earlier payment that would overpay the remaining balance
+            // (possible when the solver tolerance had to be relaxed) is capped at the amount owed; any later payments are
+            // thereby reduced to zero and dropped from the schedule, effectively shortening it
+            let regenerated =
+                basicItems[1..]
+                |> Array.scan
+                    (fun previousItem bi ->
+                        let tentative =
+                            generateItem bp bp.InterestConfig.Method bi.ScheduledPayment previousItem bi.Day
 
-                let adjustedPrincipal = bi.PrincipalPortion + bi.PrincipalBalance
-                let adjustedTotalPrincipal = bi.TotalPrincipal + bi.PrincipalBalance
+                        let adjustment =
+                            if bi.Day = finalScheduledPaymentDay then
+                                // close the balance exactly, whether underpaid or overpaid, without making the payment negative
+                                max tentative.PrincipalBalance (-(ScheduledPayment.total bi.ScheduledPayment))
+                            elif tentative.PrincipalBalance < 0L<Cent> then
+                                // cap the payment at the amount owed, without making the payment negative
+                                max tentative.PrincipalBalance (-(ScheduledPayment.total bi.ScheduledPayment))
+                            else
+                                0L<Cent>
 
-                {
-                    bi with
-                        ScheduledPayment = adjustedPayment
-                        PrincipalPortion = adjustedPrincipal
-                        PrincipalBalance = 0L<Cent>
-                        TotalPrincipal = adjustedTotalPrincipal
-                }
-            else
-                bi
-        )
+                        if adjustment = 0L<Cent> then
+                            tentative
+                        else
+                            generateItem
+                                bp
+                                bp.InterestConfig.Method
+                                (adjustPayment adjustment bi.ScheduledPayment)
+                                previousItem
+                                bi.Day
+                    )
+                    basicItems[0]
+            // drop any trailing payments that the adjustment reduced to zero, effectively shortening the schedule
+            let rec trimmedLength length =
+                if
+                    length > 1
+                    && ScheduledPayment.total regenerated[length - 1].ScheduledPayment = 0L<Cent>
+                    && ScheduledPayment.total basicItems[length - 1].ScheduledPayment <> 0L<Cent>
+                then
+                    trimmedLength (length - 1)
+                else
+                    length
+
+            regenerated[.. (trimmedLength regenerated.Length) - 1]
 
     /// calculates the number of days between two offset days on which interest is chargeable
     let calculateBasicSchedule bp =
@@ -1079,7 +1104,13 @@ module Scheduling =
                     |> Array.unfold (equaliseInterest bp paymentDays initialBasicItem paymentCount feeTotal paymentMap)
                     |> Array.last
                 | _ -> basicItems
-                |> adjustFinalPayment finalScheduledPaymentDay bp.ScheduleConfig.IsAutoGenerateSchedule
+                |> adjustFinalPayment bp finalScheduledPaymentDay bp.ScheduleConfig.IsAutoGenerateSchedule
+            // the final scheduled payment day may have moved earlier if adjusting the final payment shortened the schedule
+            let finalScheduledPaymentDay =
+                items
+                |> Array.tryFindBack (_.ScheduledPayment >> ScheduledPayment.isSome)
+                |> Option.map _.Day
+                |> Option.defaultValue finalScheduledPaymentDay
             // calculate the total principal paid over the schedule
             let principalTotal = items |> Array.sumBy _.PrincipalPortion
             // calculate the total interest accrued over the schedule

--- a/src/UnitPeriod.fs
+++ b/src/UnitPeriod.fs
@@ -103,13 +103,12 @@ module UnitPeriod =
             else
                 commonLengths periodLengths
 
-        if Array.isEmpty commonPeriodLengths then
-            periodLengths
-            |> Array.countBy id
-            |> Array.sortBy snd
-            |> Array.averageBy (snd >> decimal)
-            |> roundMidpointTowardsZero
-            |> int
+        if Array.isEmpty periodLengths then
+            // degenerate case, e.g. a same-day advance and payment: there are no intervals to measure, so default to a day
+            1
+        elif Array.isEmpty commonPeriodLengths then
+            // no interval occurs more than once, so use the average of the normalised interval lengths
+            periodLengths |> Array.averageBy decimal |> roundMidpointTowardsZero |> int
         else
             commonPeriodLengths |> Array.sortBy snd |> Array.maxBy snd |> fst
         |> normalise
@@ -245,25 +244,34 @@ module UnitPeriod =
         /// constrains the freqencies to valid values
         let constrain unitPeriodConfig =
             match unitPeriodConfig with
+            // a non-positive multiple cannot be repaired sensibly and would generate empty or unbounded schedules,
+            // so fail with a descriptive message rather than silently clamping
+            | Weekly(multiple, _)
+            | Monthly(multiple, _, _, _) when multiple < 1 ->
+                failwith $"Unit-period multiple must be a positive number: %A{unitPeriodConfig}"
             | Daily _
             | Weekly _ as c -> c
-            | SemiMonthly(_, _, day1, day2) as c when
-                day1 >= 1
+            | SemiMonthly(_, month, day1, day2) as c when
+                month >= 1
+                && month <= 12
+                && day1 >= 1
                 && day1 <= 15
                 && day2 >= 16
                 && day2 <= 31
                 && (day2 < 31 && day2 - day1 = 15 || day2 = 31 && day1 = 15)
                 ->
                 c
-            | SemiMonthly(_, _, day1, day2) as c when
-                day2 >= 1
+            | SemiMonthly(_, month, day1, day2) as c when
+                month >= 1
+                && month <= 12
+                && day2 >= 1
                 && day2 <= 15
                 && day1 >= 16
                 && day1 <= 31
                 && (day1 < 31 && day1 - day2 = 15 || day1 = 31 && day2 = 15)
                 ->
                 c
-            | Monthly(_, _, _, day) as c when day >= 1 && day <= 31 -> c
+            | Monthly(_, _, month, day) as c when month >= 1 && month <= 12 && day >= 1 && day <= 31 -> c
             | invalidConfig -> fix invalidConfig
 
     /// defines the length of a payment schedule, either by the number of payments or by the maximum duration
@@ -318,9 +326,9 @@ module UnitPeriod =
                 | Direction.Reverse ->
                     Array.unfold
                         (fun count ->
-                            let nextDate = firstPaymentDate.AddDays -count
+                            let nextDate = firstPaymentDate.AddDays count
 
-                            if nextDate <= startDate.AddDays -(int duration) then
+                            if nextDate >= startDate.AddDays -(int duration) then
                                 Some(nextDate, count - 1)
                             else
                                 None
@@ -348,9 +356,9 @@ module UnitPeriod =
                 | Direction.Reverse ->
                     Array.unfold
                         (fun i ->
-                            let nextDate = firstPaymentDate.AddDays -(i * 7 * multiple)
+                            let nextDate = firstPaymentDate.AddDays(i * 7 * multiple)
 
-                            if nextDate <= startDate.AddDays -(int duration) then
+                            if nextDate >= startDate.AddDays -(int duration) then
                                 Some(nextDate, i - 1)
                             else
                                 None
@@ -445,9 +453,9 @@ module UnitPeriod =
                     Array.unfold
                         (fun count ->
                             let nextDate =
-                                firstPaymentDate.AddMonths(-count * multiple) |> adjustMonthEnd trackingDay
+                                firstPaymentDate.AddMonths(count * multiple) |> adjustMonthEnd trackingDay
 
-                            if nextDate <= startDate.AddDays -(int duration) then
+                            if nextDate >= startDate.AddDays -(int duration) then
                                 Some(nextDate, count - 1)
                             else
                                 None
@@ -471,6 +479,9 @@ module UnitPeriod =
             match interval with
             | Day -> Daily firstTransferDate
             | Week multiple -> Weekly(multiple, firstTransferDate)
+            | SemiMonth when Array.length transferDates = 1 ->
+                // a single transfer date cannot supply both semi-monthly tracking days, so derive the second day from the first
+                Config.defaultSemiMonthly firstTransferDate
             | SemiMonth ->
                 if Array.length transferDates % 2 = 1 then // deal with odd numbers of transfer dates
                     transferDates

--- a/tests/ActualPaymentTests.fs
+++ b/tests/ActualPaymentTests.fs
@@ -1149,3 +1149,27 @@ module ActualPaymentTests =
 
         let expected = true
         actual |> should equal expected
+
+    // regression test: a refund issued on a scheduled-payment day was previously classified as an underpayment,
+    // incurring a late-payment charge and later being mislabelled as paid-later-owing
+    [<Fact>]
+    let ActualPaymentTest024 () =
+        let description = "Refund on a scheduled-payment day is classified as a refund"
+
+        let actualPayments =
+            Map [
+                4<OffsetDay>, [| ActualPayment.quickConfirmed 456_88L<Cent> |]
+                35<OffsetDay>, [| ActualPayment.quickConfirmed (-50_00L<Cent>) |]
+            ]
+
+        let schedules = amortise parameters1 actualPayments
+
+        let item35 = schedules.AmortisationSchedule.ScheduleItems |> Map.find 35<OffsetDay>
+
+        let actual =
+            item35.PaymentStatus, item35.NetEffect, item35.NewCharges, item35.PrincipalPortion
+
+        let expected =
+            Refunded, -50_00L<Cent>, Array.empty<AppliedCharge>, -50_00L<Cent>
+
+        actual |> should equal expected

--- a/tests/ActualPaymentTests.fs
+++ b/tests/ActualPaymentTests.fs
@@ -1239,6 +1239,72 @@ module ActualPaymentTests =
 
         actual |> should equal expected
 
+    // regression test: a charge attached to a failed payment (e.g. an insufficient-funds charge on a failed retry) was
+    // previously dropped entirely when it fell on a day where no payment was due
+    [<Fact>]
+    let ActualPaymentTest023 () =
+        let description =
+            "Failed payment with an insufficient-funds charge on a non-schedule day: the charge still applies"
+
+        let p = {
+            parameters1 with
+                Advanced.ChargeConfig =
+                    Some {
+                        ChargeTypes =
+                            Map [
+                                Charge.LatePayment,
+                                {
+                                    Value = 10_00L<Cent>
+                                    ChargeGrouping = Charge.ChargeGrouping.OneChargeTypePerDay
+                                    ChargeHolidays = [||]
+                                }
+                                Charge.InsufficientFunds,
+                                {
+                                    Value = 7_50L<Cent>
+                                    ChargeGrouping = Charge.ChargeGrouping.OneChargeTypePerDay
+                                    ChargeHolidays = [||]
+                                }
+                            ]
+                    }
+        }
+
+        // first instalment paid on time, then a failed retry (with an insufficient-funds charge) on a non-schedule day
+        let actualPayments =
+            Map [
+                4<OffsetDay>, [| ActualPayment.quickConfirmed 456_88L<Cent> |]
+                14<OffsetDay>,
+                [|
+                    ActualPayment.quickFailed 456_88L<Cent> (ValueSome Charge.InsufficientFunds)
+                |]
+            ]
+
+        let schedules = amortise p actualPayments
+
+        let item14 = schedules.AmortisationSchedule.ScheduleItems |> Map.find 14<OffsetDay>
+        let item35 = schedules.AmortisationSchedule.ScheduleItems |> Map.find 35<OffsetDay>
+
+        let actual =
+            item14.NewCharges, item14.ChargesBalance, item35.NewCharges, item35.ChargesBalance
+
+        // the insufficient-funds charge applies on day 14 even though nothing is due that day, and the late-payment
+        // charge for the missed day-35 payment is carried on top of it
+        let expected =
+            [|
+                {
+                    ChargeType = Charge.InsufficientFunds
+                    Total = 7_50L<Cent>
+                }
+            |],
+            7_50L<Cent>,
+            [|
+                {
+                    ChargeType = Charge.LatePayment
+                    Total = 10_00L<Cent>
+                }
+            |],
+            17_50L<Cent>
+
+        actual |> should equal expected
 
     // regression test: a refund issued on a scheduled-payment day was previously classified as an underpayment,
     // incurring a late-payment charge and later being mislabelled as paid-later-owing

--- a/tests/ActualPaymentTests.fs
+++ b/tests/ActualPaymentTests.fs
@@ -1150,6 +1150,96 @@ module ActualPaymentTests =
         let expected = true
         actual |> should equal expected
 
+    // regression test: under the AddChargesAndInterest option, the portions previously summed to more than the amount
+    // collected (interest and charges were double-counted) and the scheduled-payment adjustment had a sign error; the
+    // adjustment now increases the payment due (and the amount collected, for payments not yet due) by the charges and
+    // interest, so the portions sum exactly to the net effect
+    [<Fact>]
+    let ActualPaymentTest021 () =
+        let description =
+            "Schedule with a missed payment under the add-charges-and-interest option: charges and interest are added to the payment due and genuinely collected"
+
+        let p = {
+            parameters1 with
+                Advanced.PaymentConfig.ScheduledPaymentOption = AddChargesAndInterest
+        }
+
+        // miss day 35 (incurring a late-payment charge), pay double on day 66
+        let actualPayments =
+            Map [
+                4<OffsetDay>, [| ActualPayment.quickConfirmed 456_88L<Cent> |]
+                66<OffsetDay>, [| ActualPayment.quickConfirmed 913_76L<Cent> |]
+                94<OffsetDay>, [| ActualPayment.quickConfirmed 456_88L<Cent> |]
+                125<OffsetDay>, [| ActualPayment.quickConfirmed 456_88L<Cent> |]
+            ]
+
+        let schedules = amortise p actualPayments
+
+        // on every day, the portions must sum exactly to the net effect (nothing is written off or double-counted)
+        let conservationViolationCount =
+            schedules.AmortisationSchedule.ScheduleItems
+            |> Map.filter (fun _ si ->
+                si.ChargesPortion + si.InterestPortion + si.FeePortion + si.PrincipalPortion
+                <> si.NetEffect
+            )
+            |> Map.count
+
+        // on day 66, the late-payment charge and accrued interest are added to the scheduled payment as an adjustment
+        let item66 = schedules.AmortisationSchedule.ScheduleItems |> Map.find 66<OffsetDay>
+
+        // the sum of the scheduled payment totals reflects the upward adjustments
+        let scheduledPaymentTotal =
+            schedules.AmortisationSchedule.ScheduleItems
+            |> Map.toArray
+            |> Array.sumBy (snd >> _.ScheduledPayment >> ScheduledPayment.total)
+
+        let actual =
+            conservationViolationCount,
+            item66.ScheduledPayment.Adjustment,
+            item66.PaymentDue,
+            item66.ChargesPortion,
+            item66.InterestPortion,
+            item66.PrincipalPortion,
+            scheduledPaymentTotal
+
+        let expected =
+            0, 551_19L<Cent>, 1008_07L<Cent>, 10_00L<Cent>, 541_19L<Cent>, 362_57L<Cent>, 3132_60L<Cent>
+
+        actual |> should equal expected
+
+    // regression test: under the AddChargesAndInterest option, a projected schedule assumes future payments are made
+    // including the interest adjustments, so the balance closes by the end of the schedule
+    [<Fact>]
+    let ActualPaymentTest022 () =
+        let description =
+            "Projected schedule under the add-charges-and-interest option: interest is added to each payment due and the balance closes"
+
+        let p = {
+            parameters1 with
+                Basic.EvaluationDate = Date(2022, 11, 26) // evaluated on the start date, so the whole schedule is projected
+                Advanced.PaymentConfig.ScheduledPaymentOption = AddChargesAndInterest
+        }
+
+        let schedules = amortise p Map.empty
+
+        let item4 = schedules.AmortisationSchedule.ScheduleItems |> Map.find 4<OffsetDay>
+
+        let actual =
+            schedules.AmortisationSchedule.FinalStats.FinalBalanceStatus,
+            item4.ScheduledPayment.Adjustment,
+            item4.PaymentDue,
+            item4.NetEffect,
+            item4.InterestPortion,
+            item4.PrincipalPortion
+
+        // the first payment due is the scheduled 456.88 plus the 48.00 interest accrued to date, so the full 456.88 is
+        // apportioned to principal and the balance amortises ahead of the as-scheduled case, closing early
+        let expected =
+            ClosedBalance, 48_00L<Cent>, 504_88L<Cent>, 504_88L<Cent>, 48_00L<Cent>, 456_88L<Cent>
+
+        actual |> should equal expected
+
+
     // regression test: a refund issued on a scheduled-payment day was previously classified as an underpayment,
     // incurring a late-payment charge and later being mislabelled as paid-later-owing
     [<Fact>]

--- a/tests/ActualPaymentTestsExtra.fs
+++ b/tests/ActualPaymentTestsExtra.fs
@@ -897,3 +897,208 @@ module ActualPaymentTestsExtra =
             }
 
         actual |> should equal expected
+
+    [<Fact>]
+    let ActualPaymentTestExtra010 () =
+        // regression test: rescheduling with an auto-generated payment plan must cancel the original payments
+        // falling on or after the reschedule day and size the new level payment against the outstanding balance
+        // rather than the full original principal
+        let p: Parameters = {
+            Basic = {
+                EvaluationDate = Date(2024, 2, 15) // day 45
+                StartDate = Date(2024, 1, 1)
+                Principal = 1000_00L<Cent>
+                ScheduleConfig =
+                    AutoGenerateSchedule {
+                        UnitPeriodConfig = Monthly(1, 2024, 2, 1) // payments on days 31, 60, 91 and 121
+                        ScheduleLength = PaymentCount 4
+                    }
+                PaymentConfig = {
+                    LevelPaymentOption = LowerFinalPayment
+                    Rounding = RoundUp
+                }
+                FeeConfig = ValueNone
+                InterestConfig = {
+                    Method = Interest.Method.Actuarial
+                    StandardRate = Interest.Rate.Daily <| Percent 0.8m
+                    Cap = {
+                        TotalAmount = Amount.Percentage(Percent 100m, Restriction.NoLimit)
+                        DailyAmount = Amount.Percentage(Percent 0.8m, Restriction.NoLimit)
+                    }
+                    Rounding = RoundDown
+                    AprMethod = Apr.CalculationMethod.UsActuarial 8
+                }
+            }
+            Advanced = {
+                PaymentConfig = {
+                    ScheduledPaymentOption = AsScheduled
+                    Minimum = NoMinimumPayment
+                    Timeout = 3<DurationDay>
+                }
+                FeeConfig = ValueNone
+                ChargeConfig = None
+                InterestConfig = {
+                    InitialGracePeriod = 0<DurationDay>
+                    PromotionalRates = [||]
+                    RateOnNegativeBalance = Interest.Rate.Zero
+                }
+                SettlementDay = SettlementDay.NoSettlement
+                TrimEnd = true
+            }
+        }
+
+        // only the first scheduled payment has been made, and only partially
+        let actualPayments =
+            Map [ 31<OffsetDay>, [| ActualPayment.quickConfirmed 350_00L<Cent> |] ]
+
+        let rescheduleDay = p.Basic.EvaluationDate |> OffsetDay.fromDate p.Basic.StartDate
+
+        let rp: RescheduleParameters = {
+            FeeSettlementRebate = Fee.SettlementRebate.Zero
+            PaymentSchedule =
+                AutoGenerateSchedule {
+                    UnitPeriodConfig = Weekly(2, Date(2024, 2, 20)) // new plan: fortnightly payments from day 50
+                    ScheduleLength = PaymentCount 6
+                }
+            RateOnNegativeBalance = Interest.Rate.Zero
+            PromotionalInterestRates = [||]
+            SettlementDay = SettlementDay.NoSettlement
+        }
+
+        let schedules = reschedule p rp actualPayments
+        let items = schedules.NewSchedules.AmortisationSchedule.ScheduleItems
+
+        // the original payments falling on or after the reschedule day must be zeroed by the new plan
+        // (the day-121 payment is trimmed from the schedule as the balance is already closed by day 120)
+        let actualCancelledOriginals =
+            items
+            |> Map.filter (fun day si -> day >= rescheduleDay && si.ScheduledPayment.Original.IsSome)
+            |> Map.map (fun _ si -> ScheduledPayment.total si.ScheduledPayment, si.PaymentDue)
+
+        let expectedCancelledOriginals =
+            Map [
+                60<OffsetDay>, (0L<Cent>, 0L<Cent>)
+                91<OffsetDay>, (0L<Cent>, 0L<Cent>)
+            ]
+
+        actualCancelledOriginals |> should equal expectedCancelledOriginals
+
+        // from the reschedule day onwards, only the new plan is due, as rescheduled payments carrying the
+        // reschedule day, with the level payment sized against the outstanding balance on the reschedule day
+        let actualNewPlan =
+            items
+            |> Map.filter (fun day si ->
+                day >= rescheduleDay && ScheduledPayment.total si.ScheduledPayment > 0L<Cent>
+            )
+            |> Map.map (fun _ si -> si.ScheduledPayment.Original, si.ScheduledPayment.Rescheduled)
+
+        let expectedNewPlan =
+            [ 50, 222_03L; 64, 222_03L; 78, 222_03L; 92, 222_03L; 106, 222_03L; 120, 221_97L ]
+            |> List.map (fun (day, value) ->
+                day * 1<OffsetDay>,
+                ((ValueNone: int64<Cent> voption),
+                 ValueSome {
+                     Value = value * 1L<Cent>
+                     RescheduleDay = rescheduleDay
+                 })
+            )
+            |> Map.ofList
+
+        actualNewPlan |> should equal expectedNewPlan
+
+        // the new plan retires the outstanding balance in full
+        schedules.NewSchedules.AmortisationSchedule.FinalStats.FinalBalanceStatus
+        |> should equal ClosedBalance
+
+        let finalDay, finalItem = items |> Map.maxKeyValue
+        finalDay |> should equal 120<OffsetDay>
+        finalItem.BalanceStatus |> should equal ClosedBalance
+        finalItem.PrincipalBalance |> should equal 0L<Cent>
+
+    [<Fact>]
+    let ActualPaymentTestExtra011 () =
+        // regression test: rolling over a loan must re-base the pro-rata fee rebate day onto the new schedule's
+        // day axis (day 0 = rollover day) so that no rebate remains once the original final payment date has passed
+        let p: Parameters = {
+            Basic = {
+                EvaluationDate = Date(2024, 2, 15) // rollover on day 45
+                StartDate = Date(2024, 1, 1)
+                Principal = 1000_00L<Cent>
+                ScheduleConfig =
+                    AutoGenerateSchedule {
+                        UnitPeriodConfig = Monthly(1, 2024, 2, 1) // payments on days 31, 60, 91 and 121
+                        ScheduleLength = PaymentCount 4
+                    }
+                PaymentConfig = {
+                    LevelPaymentOption = LowerFinalPayment
+                    Rounding = RoundUp
+                }
+                FeeConfig =
+                    ValueSome {
+                        FeeType = Fee.FeeType.CabOrCsoFee(Amount.Percentage(Percent 100m, Restriction.NoLimit))
+                        Rounding = RoundDown
+                        FeeAmortisation = Fee.FeeAmortisation.AmortiseProportionately
+                    }
+                InterestConfig = {
+                    Method = Interest.Method.Actuarial
+                    StandardRate = Interest.Rate.Daily <| Percent 0.8m
+                    Cap = {
+                        TotalAmount = Amount.Percentage(Percent 100m, Restriction.NoLimit)
+                        DailyAmount = Amount.Percentage(Percent 0.8m, Restriction.NoLimit)
+                    }
+                    Rounding = RoundDown
+                    AprMethod = Apr.CalculationMethod.UsActuarial 8
+                }
+            }
+            Advanced = {
+                PaymentConfig = {
+                    ScheduledPaymentOption = AsScheduled
+                    Minimum = NoMinimumPayment
+                    Timeout = 3<DurationDay>
+                }
+                FeeConfig =
+                    ValueSome {
+                        SettlementRebate = Fee.SettlementRebate.ProRata
+                    }
+                ChargeConfig = None
+                InterestConfig = {
+                    InitialGracePeriod = 0<DurationDay>
+                    PromotionalRates = [||]
+                    RateOnNegativeBalance = Interest.Rate.Zero
+                }
+                SettlementDay = SettlementDay.NoSettlement
+                TrimEnd = true
+            }
+        }
+
+        let rp: RolloverParameters = {
+            OriginalFinalPaymentDay = 121<OffsetDay>
+            PaymentSchedule =
+                AutoGenerateSchedule {
+                    UnitPeriodConfig = Monthly(1, 2024, 3, 15) // new monthly payments from new-schedule day 29
+                    ScheduleLength = PaymentCount 4
+                }
+            InterestConfig = p.Basic.InterestConfig
+            PaymentConfig = p.Basic.PaymentConfig
+            FeeHandling = Fee.FeeHandling.CarryOverAsIs
+        }
+
+        let schedules = rollOver p rp Map.empty
+
+        // the original final payment day (121) re-based onto the new schedule's day axis is day 76 (= 121 - 45),
+        // so the carried-over fee of 371.90 is pro-rated against day 76: on day 29 the rebate is
+        // 371.90 * (76 - 29) / 76 = 230.00 (rounded up), and at or after day 76 no rebate remains
+        let actual =
+            schedules.NewSchedules.AmortisationSchedule.ScheduleItems
+            |> Map.map (fun _ si -> si.FeeBalance, si.FeeRebateIfSettled)
+
+        let expected =
+            Map [
+                0<OffsetDay>, (371_90L<Cent>, 371_90L<Cent>)
+                29<OffsetDay>, (303_66L<Cent>, 230_00L<Cent>)
+                60<OffsetDay>, (224_45L<Cent>, 78_30L<Cent>)
+                90<OffsetDay>, (123_80L<Cent>, 0L<Cent>)
+                121<OffsetDay>, (0L<Cent>, 0L<Cent>)
+            ]
+
+        actual |> should equal expected

--- a/tests/AprUsActuarialTestsExtra.fs
+++ b/tests/AprUsActuarialTestsExtra.fs
@@ -71,3 +71,100 @@ module AprActuarialTestsExtra =
     [<MemberData(nameof (aprUsActuarialTestData))>]
     let ``Actual APRs match expected APRs under the US actuarial method`` testItem =
         testItem.ActualApr |> should equal testItem.ExpectedApr
+
+    /// regression tests for the unit-period detection and unit-period quotient calculations
+    module RegressionExamples =
+
+        let advance date value = {
+            TransferType = Advance
+            TransferDate = date
+            Value = value
+        }
+
+        let payment date value = {
+            TransferType = Payment
+            TransferDate = date
+            Value = value
+        }
+
+        let getApr solution =
+            solution |> getAprOr 0m |> Percent.fromDecimal |> Percent.round 2
+
+        [<Fact>]
+        let ``Reg Z (b)(5)(vi): single advance, single payment, term of a whole month`` () =
+            // $500 advanced on 2024-06-01 and repaid by a single $550 payment on 2024-07-01: the term (30 days) is equal
+            // to a whole number of months (1), so there is 1 unit-period in the term and 12 unit-periods per year,
+            // giving APR = 12 x (550/500 - 1) = 1.2 = 120.00%
+            let actual =
+                calculate (CalculationMethod.UsActuarial 5) 500_00L<Cent> (Date(2024, 6, 1)) [|
+                    payment (Date(2024, 7, 1)) 550_00L<Cent>
+                |]
+                |> getApr
+
+            let expected = Percent 120m
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Reg Z (b)(5)(vii): single advance, single payment, term of 15 days`` () =
+            // $500 advanced on 2024-06-01 and repaid by a single $550 payment on 2024-06-16: the term (15 days) is not
+            // equal to a whole number of months, so there is 1 unit-period in the term and 365/15 unit-periods per year,
+            // giving APR = 365/15 x (550/500 - 1) = 2.4333... = 243.33%
+            let actual =
+                calculate (CalculationMethod.UsActuarial 5) 500_00L<Cent> (Date(2024, 6, 1)) [|
+                    payment (Date(2024, 6, 16)) 550_00L<Cent>
+                |]
+                |> getApr
+
+            let expected = Percent 243.33m
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Irregular two-payment schedule uses the average interval as the unit-period`` () =
+            // $1000 advanced on 2024-01-01 with $550 payments at day 28 (2024-01-29) and day 64 (2024-03-05):
+            // the intervals (28 days and 36 days) normalise to 4 weeks and 1 month; neither occurs more than once, so the
+            // unit-period is the nearest to their average length ((28 + 30) / 2 = 29 days), i.e. 4 weeks (13 per year);
+            // payment 1 falls at day 28 = exactly 1 unit-period and payment 2 at day 64 = 2 unit-periods + 8/28 remainder,
+            // so per the general equation 1000 = 550/(1+i) + 550/((1 + (8/28)i)(1+i)^2), solved independently by bisection
+            // to i = 0.0600756910, giving APR = 13 x 0.0600756910 = 0.78098398... = 78.10%
+            let actual =
+                UsActuarial.generalEquation (Date(2024, 1, 1)) (Date(2024, 1, 1)) [|
+                    advance (Date(2024, 1, 1)) 1000_00L<Cent>
+                |] [|
+                    payment (Date(2024, 1, 29)) 550_00L<Cent>
+                    payment (Date(2024, 3, 5)) 550_00L<Cent>
+                |]
+                |> getApr
+
+            let expected = Percent 78.10m
+            actual |> should equal expected
+
+        /// the daily and weekly unit-period quotients must be calculated from the actual transfer dates, so moving a
+        /// payment to a later date must lower the APR
+        [<Fact>]
+        let ``Daily unit-period quotients are date-sensitive`` () =
+            // $300 advanced on 2024-01-01 with three payments of $102: with a daily unit-period, the quotient is the
+            // actual number of days from the start of the term to each payment, so each variant solves a different equation
+            let aprForDays days =
+                UsActuarial.generalEquation (Date(2024, 1, 1)) (Date(2024, 1, 1)) [|
+                    advance (Date(2024, 1, 1)) 300_00L<Cent>
+                |] (days |> Array.map (fun d -> payment (Date(2024, 1, 1).AddDays d) 102_00L<Cent>))
+                |> getApr
+
+            let actual = [| 1, 2, 3; 1, 2, 4; 1, 2, 9 |] |> Array.map (fun (a, b, c) -> aprForDays [| a; b; c |])
+            let expected = [| Percent 363.80m; Percent 311.98m; Percent 182.59m |]
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Weekly unit-period quotients are date-sensitive`` () =
+            // $300 advanced on 2024-01-01 with three roughly weekly payments of $102: the number of unit-periods and the
+            // remaining fraction are determined by dividing the actual number of days to each payment by 7, so delaying
+            // the final payment by a day must lower the APR
+            let aprForDays days =
+                UsActuarial.generalEquation (Date(2024, 1, 1)) (Date(2024, 1, 1)) [|
+                    advance (Date(2024, 1, 1)) 300_00L<Cent>
+                |] (days |> Array.map (fun d -> payment (Date(2024, 1, 1).AddDays d) 102_00L<Cent>))
+                |> getApr
+
+            let actual = aprForDays [| 7; 14; 21 |], aprForDays [| 7; 14; 22 |]
+            let expected = Percent 51.83m, Percent 50.62m
+            actual |> should equal expected

--- a/tests/EdgeCaseTests.fs
+++ b/tests/EdgeCaseTests.fs
@@ -869,3 +869,20 @@ module EdgeCaseTests =
             }
 
         actual |> should equal expected
+
+    // regression test: an empty payment schedule previously caused an unhelpful empty-sequence exception deep inside
+    // the amortisation calculation; it now fails fast with a descriptive message
+    [<Fact>]
+    let EdgeCaseTest010 () =
+        let p = {
+            parameters2 with
+                Basic.EvaluationDate = Date(2024, 4, 5)
+                Basic.StartDate = Date(2023, 5, 5)
+                Basic.Principal = 25000L<Cent>
+                Basic.ScheduleConfig = CustomSchedule Map.empty
+        }
+
+        let amortiseEmptySchedule () = amortise p Map.empty |> ignore
+
+        amortiseEmptySchedule
+        |> should (throwWithMessage "Cannot amortise an empty payment schedule") typeof<System.Exception>

--- a/tests/EdgeCaseTests.fs
+++ b/tests/EdgeCaseTests.fs
@@ -871,7 +871,8 @@ module EdgeCaseTests =
         actual |> should equal expected
 
     // regression test: an empty payment schedule previously caused an unhelpful empty-sequence exception deep inside
-    // the amortisation calculation; it now fails fast with a descriptive message
+    // the amortisation calculation; it now fails fast with a descriptive message (the basic-schedule calculation
+    // rejects configs yielding no payment days before the amortisation-level guard is reached)
     [<Fact>]
     let EdgeCaseTest010 () =
         let p = {
@@ -882,7 +883,5 @@ module EdgeCaseTests =
                 Basic.ScheduleConfig = CustomSchedule Map.empty
         }
 
-        let amortiseEmptySchedule () = amortise p Map.empty |> ignore
-
-        amortiseEmptySchedule
-        |> should (throwWithMessage "Cannot amortise an empty payment schedule") typeof<System.Exception>
+        let ex = Assert.Throws<System.Exception>(fun () -> amortise p Map.empty |> ignore)
+        ex.Message |> should haveSubstring "no payment days"

--- a/tests/PaymentScheduleTests.fs
+++ b/tests/PaymentScheduleTests.fs
@@ -2190,3 +2190,203 @@ module PaymentScheduleTests =
             schedule1 = schedule2 && schedule2 = schedule3
 
         actual |> should equal true
+
+    // regression test: the payment solver previously failed ("Unable to calculate basic schedule") for the standard
+    // test fixture (£1000, 0.798% daily rate, 100% total interest cap) with 11 or more monthly payments, because the
+    // rough interest estimate ignored the interest cap and the bisection bounds were never expanded
+    [<Fact>]
+    let ``Level payment solver works under a binding total interest cap for terms of 5 to 60 months`` () =
+        let actual =
+            [| 5..60 |]
+            |> Array.forall (fun paymentCount ->
+                let schedule =
+                    Monthly.monthlyParameters 1000_00L<Cent> 8<DurationDay> paymentCount
+                    |> calculateBasicSchedule
+
+                let lastItem = schedule.Items |> Array.last
+
+                lastItem.PrincipalBalance = 0L<Cent>
+                && schedule.Stats.PrincipalTotal = 1000_00L<Cent>
+                && schedule.Stats.FinalPayment >= 0L<Cent>
+            )
+
+        actual |> should equal true
+
+    // regression test: at very high daily rates over long terms, a one-cent change in the level payment changes the
+    // final balance by more than the maximum solver tolerance, which previously made the solver fail; the solver now
+    // falls back to the nearest viable payment value and the final-payment adjustment closes the schedule
+    [<Fact>]
+    let ``Level payment solver works at a very high daily rate for terms of 4 to 24 months`` () =
+        let highRateParameters paymentCount : BasicParameters =
+            let startDate = Date(2025, 1, 1)
+
+            {
+                EvaluationDate = startDate
+                StartDate = startDate
+                Principal = 1000_00L<Cent>
+                ScheduleConfig =
+                    AutoGenerateSchedule {
+                        UnitPeriodConfig = Monthly(1, 2025, 2, 1)
+                        ScheduleLength = PaymentCount paymentCount
+                    }
+                PaymentConfig = {
+                    LevelPaymentOption = LowerFinalPayment
+                    Rounding = RoundWith MidpointRounding.AwayFromZero
+                }
+                FeeConfig = ValueNone
+                InterestConfig = {
+                    Method = Interest.Method.Actuarial
+                    StandardRate = Interest.Rate.Daily(Percent 1.4m)
+                    Cap = Interest.Cap.zero
+                    Rounding = RoundWith MidpointRounding.AwayFromZero
+                    AprMethod = Apr.CalculationMethod.UnitedKingdom 3
+                }
+            }
+
+        let actual =
+            [| 4..24 |]
+            |> Array.forall (fun paymentCount ->
+                let schedule = highRateParameters paymentCount |> calculateBasicSchedule
+                let lastItem = schedule.Items |> Array.last
+
+                lastItem.PrincipalBalance = 0L<Cent>
+                && schedule.Stats.PrincipalTotal = 1000_00L<Cent>
+                && schedule.Items
+                   |> Array.forall (fun bi -> ScheduledPayment.total bi.ScheduledPayment >= 0L<Cent>)
+            )
+
+        actual |> should equal true
+
+    // regression test: a schedule config yielding no payment days previously crashed with an uncontrolled
+    // "The input array was empty" exception (add-on interest method) or returned a degenerate schedule (actuarial)
+    [<Fact>]
+    let ``Schedule config yielding no payment days fails with a descriptive message`` () =
+        let p interestMethod scheduleConfig : BasicParameters = {
+            EvaluationDate = Date(2025, 1, 1)
+            StartDate = Date(2025, 1, 1)
+            Principal = 1000_00L<Cent>
+            ScheduleConfig = scheduleConfig
+            PaymentConfig = {
+                LevelPaymentOption = LowerFinalPayment
+                Rounding = RoundWith MidpointRounding.AwayFromZero
+            }
+            FeeConfig = ValueNone
+            InterestConfig = {
+                Method = interestMethod
+                StandardRate = Interest.Rate.Daily(Percent 0.798m)
+                Cap = interestCapExample
+                Rounding = RoundWith MidpointRounding.AwayFromZero
+                AprMethod = Apr.CalculationMethod.UnitedKingdom 3
+            }
+        }
+
+        // a fixed schedule whose unit-period config starts before the loan start date yields no payment days
+        let fixedSchedulesPredatingStartDate =
+            FixedSchedules [|
+                {
+                    UnitPeriodConfig = Monthly(1, 2024, 12, 15)
+                    PaymentCount = 4
+                    PaymentValue = 300_00L<Cent>
+                    ScheduleType = ScheduleType.Original
+                }
+            |]
+
+        let errorMessage bp =
+            try
+                calculateBasicSchedule bp |> ignore
+                "no exception raised"
+            with ex ->
+                ex.Message
+
+        p Interest.Method.AddOn (CustomSchedule Map.empty)
+        |> errorMessage
+        |> should haveSubstring "yields no payment days"
+
+        p Interest.Method.Actuarial (CustomSchedule Map.empty)
+        |> errorMessage
+        |> should haveSubstring "yields no payment days"
+
+        p Interest.Method.AddOn fixedSchedulesPredatingStartDate
+        |> errorMessage
+        |> should haveSubstring "start date"
+
+    // regression test: the final-payment adjustment previously dumped the whole rounding overpayment onto the final
+    // payment with no floor, producing a negative final scheduled payment (here: level 20p, final -60p); the payments
+    // are now floored at zero and the schedule is shortened instead
+    [<Fact>]
+    let ``Final payment is never negative and overpayment shortens the schedule`` () =
+        let startDate = Date(2025, 1, 1)
+
+        let p: BasicParameters = {
+            EvaluationDate = startDate
+            StartDate = startDate
+            Principal = 20_00L<Cent>
+            ScheduleConfig =
+                AutoGenerateSchedule {
+                    UnitPeriodConfig = Weekly(1, startDate.AddDays 7)
+                    ScheduleLength = PaymentCount 104
+                }
+            PaymentConfig = {
+                LevelPaymentOption = LowerFinalPayment
+                Rounding = RoundUp
+            }
+            FeeConfig = ValueNone
+            InterestConfig = {
+                Method = Interest.Method.Actuarial
+                StandardRate = Interest.Rate.Zero
+                Cap = Interest.Cap.zero
+                Rounding = RoundWith MidpointRounding.AwayFromZero
+                AprMethod = Apr.CalculationMethod.UnitedKingdom 3
+            }
+        }
+
+        let schedule = calculateBasicSchedule p
+
+        schedule.Stats.LevelPayment |> should equal 20L<Cent>
+        schedule.Stats.FinalPayment |> should equal 20L<Cent>
+        schedule.Stats.ScheduledPaymentTotal |> should equal 20_00L<Cent>
+        schedule.Stats.PrincipalTotal |> should equal 20_00L<Cent>
+        // 100 payments of 20p repay the £20 principal exactly, so the schedule is shortened from 104 to 100 payments
+        schedule.Stats.LastScheduledPaymentDay |> should equal 700<OffsetDay>
+
+        (schedule.Items |> Array.last).PrincipalBalance |> should equal 0L<Cent>
+
+        schedule.Items
+        |> Array.forall (fun bi -> ScheduledPayment.total bi.ScheduledPayment >= 0L<Cent>)
+        |> should equal true
+
+    // regression test: a single payment scheduled on day 0 previously doubled the principal total, as the final-payment
+    // adjustment also matched the day-0 seed item generated by Array.scan and folded its full principal balance into
+    // the principal portion
+    [<Fact>]
+    let ``Single payment on day 0 does not double the principal total`` () =
+        let startDate = Date(2025, 1, 1)
+
+        let p: BasicParameters = {
+            EvaluationDate = startDate
+            StartDate = startDate
+            Principal = 1000_00L<Cent>
+            ScheduleConfig =
+                AutoGenerateSchedule {
+                    UnitPeriodConfig = Daily startDate
+                    ScheduleLength = PaymentCount 1
+                }
+            PaymentConfig = {
+                LevelPaymentOption = LowerFinalPayment
+                Rounding = RoundWith MidpointRounding.AwayFromZero
+            }
+            FeeConfig = ValueNone
+            InterestConfig = {
+                Method = Interest.Method.Actuarial
+                StandardRate = Interest.Rate.Daily(Percent 0.798m)
+                Cap = interestCapExample
+                Rounding = RoundWith MidpointRounding.AwayFromZero
+                AprMethod = Apr.CalculationMethod.UnitedKingdom 3
+            }
+        }
+
+        let schedule = calculateBasicSchedule p
+
+        schedule.Stats.PrincipalTotal |> should equal 1000_00L<Cent>
+        schedule.Stats.FinalPayment |> should equal 1000_00L<Cent>
+        (schedule.Items |> Array.last).PrincipalBalance |> should equal 0L<Cent>

--- a/tests/PaymentScheduleTests.fs
+++ b/tests/PaymentScheduleTests.fs
@@ -2190,3 +2190,98 @@ module PaymentScheduleTests =
             schedule1 = schedule2 && schedule2 = schedule3
 
         actual |> should equal true
+
+    /// regression tests for unit-period detection and unit-period config handling
+    /// (these would ideally live in UnitPeriodConfigTests.fs, but that file is currently excluded from the test project)
+    module UnitPeriodDetection =
+
+        [<Fact>]
+        let ``Nearest unit-period for a single payment 15 days after the advance is a semi-month`` () =
+            let term =
+                transactionTerm (Date(2024, 1, 1)) (Date(2024, 1, 1)) (Date(2024, 1, 16)) (Date(2024, 1, 1))
+
+            let actual = nearest term [| Date(2024, 1, 1) |] [| Date(2024, 1, 16) |]
+            let expected = SemiMonth
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Nearest unit-period with no repeated interval is the average of the interval lengths`` () =
+            // intervals of 20 and 45 days normalise to 15 and 30 days, averaging 22.5 -> 22 days, nearest to 4 weeks
+            let term =
+                transactionTerm (Date(2024, 1, 1)) (Date(2024, 1, 1)) (Date(2024, 3, 6)) (Date(2024, 1, 1))
+
+            let actual = nearest term [| Date(2024, 1, 1) |] [| Date(2024, 1, 21); Date(2024, 3, 6) |]
+            let expected = Week 4
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Nearest unit-period with no intervals at all falls back to a day`` () =
+            let term =
+                transactionTerm (Date(2024, 1, 1)) (Date(2024, 1, 1)) (Date(2024, 1, 1)) (Date(2024, 1, 1))
+
+            let actual = nearest term [| Date(2024, 1, 1) |] [| Date(2024, 1, 1) |]
+            let expected = Day
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Detect semi-monthly config from a single transfer date`` () =
+            let actual = detect Direction.Forward SemiMonth [| Date(2024, 1, 15) |]
+            let expected = SemiMonthly(2024, 1, 15, 31)
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Constrain repairs a monthly config with an out-of-range month`` () =
+            let actual = Config.constrain (Monthly(1, 2024, 13, 15))
+            let expected = Monthly(1, 2024, 12, 15)
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Constrain repairs a semi-monthly config with an out-of-range month`` () =
+            let actual =
+                generatePaymentSchedule (PaymentCount 3) Direction.Forward (SemiMonthly(2024, 13, 15, 31))
+
+            let expected = [| Date(2024, 12, 15); Date(2024, 12, 31); Date(2025, 1, 15) |]
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Constrain rejects a non-positive weekly multiple`` () =
+            (fun () -> Config.constrain (Weekly(0, Date(2024, 1, 1))) |> ignore)
+            |> should throw typeof<exn>
+
+        [<Fact>]
+        let ``Constrain rejects a non-positive monthly multiple`` () =
+            (fun () -> Config.constrain (Monthly(0, 2024, 1, 15)) |> ignore)
+            |> should throw typeof<exn>
+
+        [<Fact>]
+        let ``Reverse daily schedule with max duration generates all dates within the window`` () =
+            let actual =
+                generatePaymentSchedule
+                    (MaxDuration(Date(2024, 6, 1), 30<DurationDay>))
+                    Direction.Reverse
+                    (Daily(Date(2024, 6, 1)))
+
+            let expected = [| 0..30 |] |> Array.map (Date(2024, 5, 2).AddDays)
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Reverse weekly schedule with max duration generates all dates within the window`` () =
+            let actual =
+                generatePaymentSchedule
+                    (MaxDuration(Date(2024, 6, 1), 28<DurationDay>))
+                    Direction.Reverse
+                    (Weekly(1, Date(2024, 6, 1)))
+
+            let expected = [| 0..4 |] |> Array.map (fun i -> Date(2024, 5, 4).AddDays(i * 7))
+            actual |> should equal expected
+
+        [<Fact>]
+        let ``Reverse monthly schedule with max duration generates all dates within the window`` () =
+            let actual =
+                generatePaymentSchedule
+                    (MaxDuration(Date(2024, 6, 30), 92<DurationDay>))
+                    Direction.Reverse
+                    (Monthly(1, 2024, 6, 30))
+
+            let expected = [| Date(2024, 3, 30); Date(2024, 4, 30); Date(2024, 5, 30); Date(2024, 6, 30) |]
+            actual |> should equal expected

--- a/tests/QuoteTests.fs
+++ b/tests/QuoteTests.fs
@@ -2007,3 +2007,105 @@ module QuoteTests =
             }
 
         actual |> should equal expected
+
+    // regression test: this scenario previously crashed with an empty-array exception in calculateStatutoryFeeRebate,
+    // because no original scheduled payment day precedes the quote day (the settlement part-period now runs from the
+    // start date instead)
+    [<Fact>]
+    let QuoteTest026 () =
+        let description =
+            "Quote on a day before the first scheduled payment day, UK APR method with pro-rata fee rebate"
+
+        let p = {
+            parameters2 with
+                Basic.EvaluationDate = Date(2022, 12, 1) // day 5, first scheduled payment on day 35
+                Basic.StartDate = Date(2022, 11, 26)
+                Basic.Principal = 1500_00L<Cent>
+                Basic.ScheduleConfig =
+                    AutoGenerateSchedule {
+                        UnitPeriodConfig = Monthly(1, 2022, 11, 31)
+                        ScheduleLength = PaymentCount 5
+                    }
+                Basic.FeeConfig =
+                    ValueSome {
+                        FeeType = Fee.FeeType.CabOrCsoFee(Amount.Percentage(Percent 150m, Restriction.NoLimit))
+                        Rounding = RoundDown
+                        FeeAmortisation = Fee.FeeAmortisation.AmortiseProportionately
+                    }
+                Advanced.FeeConfig =
+                    ValueSome {
+                        SettlementRebate = Fee.SettlementRebate.ProRata
+                    }
+        }
+
+        let actual = getQuote p Map.empty |> _.QuoteResult
+
+        let expected =
+            PaymentQuote {
+                PaymentValue = 1740_00L<Cent>
+                Apportionment = {
+                    PrincipalPortion = 1500_00L<Cent>
+                    FeePortion = 90_00L<Cent>
+                    InterestPortion = 150_00L<Cent>
+                    ChargesPortion = 0L<Cent>
+                }
+                FeeRebateIfSettled = 2160_00L<Cent>
+            }
+
+        actual |> should equal expected
+
+    // regression test: the settlement figure was previously composed using the pro-rata fee rebate even when the higher
+    // UK statutory rebate was applied, over-quoting the customer (1604.45 instead of 1253.13) and producing apportionment
+    // portions that included a negative fee portion and did not sum to the payment value
+    [<Fact>]
+    let QuoteTest027 () =
+        let description =
+            "Quote where the statutory rebate exceeds the pro-rata rebate: settlement figure and apportionment use the same rebate"
+
+        let p = {
+            parameters2 with
+                Basic.EvaluationDate = Date(2023, 1, 20) // day 55, mid-schedule
+                Basic.StartDate = Date(2022, 11, 26)
+                Basic.Principal = 1500_00L<Cent>
+                Basic.ScheduleConfig =
+                    AutoGenerateSchedule {
+                        UnitPeriodConfig = Monthly(1, 2022, 11, 31)
+                        ScheduleLength = PaymentCount 5
+                    }
+                Basic.FeeConfig =
+                    ValueSome {
+                        FeeType = Fee.FeeType.CabOrCsoFee(Amount.Percentage(Percent 150m, Restriction.NoLimit))
+                        Rounding = RoundDown
+                        FeeAmortisation = Fee.FeeAmortisation.AmortiseProportionately
+                    }
+                Advanced.FeeConfig =
+                    ValueSome {
+                        SettlementRebate = Fee.SettlementRebate.ProRata
+                    }
+        }
+
+        let actualPayments =
+            Map [
+                4<OffsetDay>, [| ActualPayment.quickConfirmed 1050_00L<Cent> |]
+                35<OffsetDay>, [| ActualPayment.quickConfirmed 1050_00L<Cent> |]
+            ]
+
+        let actual = getQuote p actualPayments |> _.QuoteResult
+
+        // the payment value equals principal balance + fee balance - statutory rebate + interest, the portions sum to the
+        // payment value, and the excess of the rebate over the fee balance reduces the principal portion rather than
+        // producing a negative fee portion
+        let expected =
+            PaymentQuote {
+                PaymentValue = 1253_13L<Cent>
+                Apportionment = {
+                    PrincipalPortion = 858_04L<Cent>
+                    FeePortion = 0L<Cent>
+                    InterestPortion = 395_09L<Cent>
+                    ChargesPortion = 0L<Cent>
+                }
+                FeeRebateIfSettled = 1260_00L<Cent>
+            }
+
+        actual |> should equal expected
+

--- a/tests/QuoteTests.fs
+++ b/tests/QuoteTests.fs
@@ -2109,3 +2109,59 @@ module QuoteTests =
 
         actual |> should equal expected
 
+    // regression test: a confirmed partial payment made on the quote day itself was previously ignored when generating
+    // the settlement figure, so the customer was quoted the full figure again despite having already paid
+    [<Fact>]
+    let QuoteTest028 () =
+        let description =
+            "Quote on a day with a confirmed partial payment: the payment reduces the settlement figure"
+
+        let p = {
+            parameters2 with
+                Basic.EvaluationDate = Date(2022, 12, 31) // day 35, the second scheduled payment day
+                Basic.StartDate = Date(2022, 11, 26)
+                Basic.Principal = 1500_00L<Cent>
+                Basic.ScheduleConfig =
+                    AutoGenerateSchedule {
+                        UnitPeriodConfig = Monthly(1, 2022, 11, 31)
+                        ScheduleLength = PaymentCount 5
+                    }
+                Basic.InterestConfig.AprMethod = Apr.CalculationMethod.UsActuarial 8
+        }
+
+        let paymentsWithoutSameDay =
+            Map [ 4<OffsetDay>, [| ActualPayment.quickConfirmed 456_88L<Cent> |] ]
+
+        let paymentsWithSameDay =
+            paymentsWithoutSameDay
+            |> Map.add 35<OffsetDay> [| ActualPayment.quickConfirmed 100_00L<Cent> |]
+
+        let quoteWithout = getQuote p paymentsWithoutSameDay |> _.QuoteResult
+        let quoteWith = getQuote p paymentsWithSameDay |> _.QuoteResult
+
+        let expectedWithout =
+            PaymentQuote {
+                PaymentValue = 1361_71L<Cent>
+                Apportionment = {
+                    PrincipalPortion = 1091_12L<Cent>
+                    FeePortion = 0L<Cent>
+                    InterestPortion = 270_59L<Cent>
+                    ChargesPortion = 0L<Cent>
+                }
+                FeeRebateIfSettled = 0L<Cent>
+            }
+
+        // the settlement figure is reduced by exactly the confirmed same-day payment, which is apportioned to interest first
+        let expectedWith =
+            PaymentQuote {
+                PaymentValue = 1261_71L<Cent>
+                Apportionment = {
+                    PrincipalPortion = 1091_12L<Cent>
+                    FeePortion = 0L<Cent>
+                    InterestPortion = 170_59L<Cent>
+                    ChargesPortion = 0L<Cent>
+                }
+                FeeRebateIfSettled = 0L<Cent>
+            }
+
+        (quoteWithout, quoteWith) |> should equal (expectedWithout, expectedWith)


### PR DESCRIPTION
One of my background agents (Fable 5) was checking critical issues with this library.

This PR hast the findings fixed, and here is a Copilot generated text-wall as descriptions:

This pull request introduces several important updates and fixes to the amortisation and APR calculation logic, with a focus on improving accuracy, regulatory compliance, and robustness in edge cases. The main areas of change are in the amortisation schedule generation, statutory fee rebate handling, APR calculation, and payment/refund classification.

**Amortisation and Fee Rebate Calculation Improvements:**

* Improved statutory fee rebate handling for UK FCA-regulated agreements, ensuring the higher of the calculated or statutory rebate is used, and correctly apportioning excess rebates between fee and principal balances. [[1]](diffhunk://#diff-5e66d930d4fee4f1aa1cb96656fa4e51169e668604823a159339212e29a937ccR1066-R1083) [[2]](diffhunk://#diff-5e66d930d4fee4f1aa1cb96656fa4e51169e668604823a159339212e29a937ccL1025-R1093) [[3]](diffhunk://#diff-5e66d930d4fee4f1aa1cb96656fa4e51169e668604823a159339212e29a937ccR1237-R1247)
* Added guards and improved handling for edge cases in amortisation, such as empty payment schedules and schedules with only rescheduled payments, to prevent calculation errors. [[1]](diffhunk://#diff-5e66d930d4fee4f1aa1cb96656fa4e51169e668604823a159339212e29a937ccR834-R837) [[2]](diffhunk://#diff-5e66d930d4fee4f1aa1cb96656fa4e51169e668604823a159339212e29a937ccR562-R567) [[3]](diffhunk://#diff-5e66d930d4fee4f1aa1cb96656fa4e51169e668604823a159339212e29a937ccL582-R594)
* Enhanced logic for suppressing or applying charges on days with no scheduled payment due, ensuring failed payment charges are still applied when appropriate.
* Refined the way charges and interest are added to scheduled payments under the `AddChargesAndInterest` option, ensuring the payment due does not exceed the outstanding balance.

**APR Calculation and Unit Period Handling:**

* Corrected the calculation of unit periods for daily and weekly schedules to use actual days between dates rather than assuming consecutive periods, improving accuracy for irregular schedules. [[1]](diffhunk://#diff-58b1ff5b4fbd1fc8309b2465554534f7fa0cca763551ff80678a8c02f891bee1L140-R150) [[2]](diffhunk://#diff-58b1ff5b4fbd1fc8309b2465554534f7fa0cca763551ff80678a8c02f891bee1L257-R272)
* Improved the robustness of the APR calculation by handling edge cases such as all transfers on the same day, and by catching overflow errors in the divisor during rate calculation. [[1]](diffhunk://#diff-58b1ff5b4fbd1fc8309b2465554534f7fa0cca763551ff80678a8c02f891bee1R92-R100) [[2]](diffhunk://#diff-58b1ff5b4fbd1fc8309b2465554534f7fa0cca763551ff80678a8c02f891bee1R319-R340)
* Updated the `roughUnitPeriodRate` to return a decimal rate (not a percentage) for use as the solver’s initial guess.

**Payment/Refund Classification Logic:**

* Refined the classification of payments and refunds, including handling refunds issued when a payment was due and ensuring partial payments on the settlement day are correctly netted against the generated settlement. [[1]](diffhunk://#diff-9a735e09c0a10d6d1d448e2c44dd18323a5fee31874ace274e4c6f627487dc86R212-R214) [[2]](diffhunk://#diff-9a735e09c0a10d6d1d448e2c44dd18323a5fee31874ace274e4c6f627487dc86L223-R230)

**Minor Adjustments and Consistency:**

* Updated calls to `adjustFinalPayment` to pass the correct parameters for consistency and correctness. [[1]](diffhunk://#diff-0337c8148e3b27665023bd2967a536d54ea0aa21ce4055b47d166c5de80867c6L237-R237) [[2]](diffhunk://#diff-f9c758ff3c89b1f3456cf0c146d44fcf60a86adbad546ec0116c072383cc16b7L241-R241)
* Minor code cleanups and improved comments for clarity.

These changes collectively enhance the accuracy, reliability, and regulatory compliance of the amortisation and APR calculation modules, especially in handling edge cases and UK-specific requirements.